### PR TITLE
add -o / --output option to write to a file

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+* add `-o` / `--output` option to write reports to a file.
+* known issue: diffing 2 files with options `--format text`, `--color` and
+  `--output` does not render color under PY2.
+
 ## 0.1.0 (2014-12-03)
 
 * add `--color` and `--no-color` options to `pycobertura diff`.

--- a/pycobertura/cli.py
+++ b/pycobertura/cli.py
@@ -22,12 +22,23 @@ reporters = {
     default='text',
     type=click.Choice(list(reporters))
 )
-def show(cobertura_file, format):
+@click.option(
+    '-o', '--output', metavar='<file>',
+    type=click.File('wb'),
+    help='Write output to <file> instead of stdout.'
+)
+def show(cobertura_file, format, output):
     """show the coverage summary"""
     cobertura = Cobertura(cobertura_file)
     Reporter = reporters[format]
-    report = Reporter(cobertura)
-    print(report.generate())
+    reporter = Reporter(cobertura)
+    report = reporter.generate()
+
+    if not isinstance(report, bytes):
+        report = report.encode('utf-8')
+
+    isatty = True if output is None else output.isatty()
+    click.echo(report, file=output, nl=isatty)
 
 
 delta_reporters = {
@@ -45,14 +56,38 @@ delta_reporters = {
          'when standard output is connected to a terminal. This has no effect '
          'with the HTML output format.')
 @click.option(
-    '-f', '--format',
-    default='text',
+    '-f', '--format', default='text',
     type=click.Choice(list(delta_reporters))
 )
-def diff(cobertura_file1, cobertura_file2, color, format):
+@click.option(
+    '-o', '--output', metavar='<file>',
+    type=click.File('wb'),
+    help='Write output to <file> instead of stdout.'
+)
+def diff(cobertura_file1, cobertura_file2, color, format, output):
     """compare two coverage files"""
     cobertura1 = Cobertura(cobertura_file1)
     cobertura2 = Cobertura(cobertura_file2)
     Reporter = delta_reporters[format]
-    report = Reporter(cobertura1, cobertura2, color=color)
-    print(report.generate())
+    reporter_args = [cobertura1, cobertura2]
+    reporter_kwargs = {}
+
+    isatty = True if output is None else output.isatty()
+    if format == 'text':
+        color = isatty if color is None else color is True
+        reporter_kwargs['color'] = color
+
+    reporter = Reporter(*reporter_args, **reporter_kwargs)
+    report = reporter.generate()
+
+    if not isinstance(report, bytes):
+        report = report.encode('utf-8')
+
+    # FIXME: In Click 3.x, the color is stripped out if the output file is
+    # detected to not support ANSI codes causing `-o outfile --color` to write
+    # to `outfile` without colors. In Click 4.x, `echo()` will take a
+    # color=True/False flag which will allow us to override ANSI code
+    # auto-detection.
+    # https://github.com/mitsuhiko/click/commit/5cf7f2ddfba328070751cbda32782520d4e0d6f5
+    #click.echo(report, file=output, nl=isatty, color=color)  # click 4.x
+    click.echo(report, file=output, nl=isatty)

--- a/pycobertura/reporters.py
+++ b/pycobertura/reporters.py
@@ -136,11 +136,9 @@ class HtmlReporter(TextReporter):
 
 
 class DeltaReporter(object):
-    def __init__(self, cobertura1, cobertura2, color=None):
+    def __init__(self, cobertura1, cobertura2):
         self.cobertura1 = cobertura1
         self.cobertura2 = cobertura2
-
-        self.color = sys.stdout.isatty() if color is None else color is True
 
     def get_diff_line(self, line1, line2):
         if line1 is not None:
@@ -239,6 +237,15 @@ class DeltaReporter(object):
 
 
 class TextReporterDelta(DeltaReporter):
+    def __init__(self, *args, **kwargs):
+        """
+        Takes the same arguments as `DeltaReporter` but also takes the keyword
+        argument `color` which can be set to True or False depending if the
+        generated report should be colored or not (default `color=False`).
+	"""
+        self.color = kwargs.pop('color', False)
+        super(TextReporterDelta, self).__init__(*args, **kwargs)
+
     def format_row(self, row):
         class_name, total_lines, total_misses, line_rate, missed_lines = row
 
@@ -285,10 +292,6 @@ class TextReporterDelta(DeltaReporter):
 
 
 class HtmlReporterDelta(TextReporterDelta):
-    def __init__(self, *args, **kwargs):
-        kwargs['color'] = False
-        super(HtmlReporterDelta, self).__init__(*args, **kwargs)
-
     def format_row(self, row):
         class_name, total_lines, total_misses, line_rate, missed_lines = row
 

--- a/pycobertura/utils.py
+++ b/pycobertura/utils.py
@@ -1,5 +1,4 @@
 import colorama
-import sys
 
 
 def colorize(text, color):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,11 +1,17 @@
 from click.testing import CliRunner
+import sys
+
+PY2 = sys.version_info.major == 2
 
 
 def test_show__format_default():
     from pycobertura.cli import show
 
     runner = CliRunner()
-    result = runner.invoke(show, ['tests/dummy.original.xml'])
+    result = runner.invoke(show,
+        ['tests/dummy.original.xml'],
+        catch_exceptions=False
+    )
     assert result.output == """\
 Name           Stmts    Miss  Cover    Missing
 -----------  -------  ------  -------  ---------
@@ -14,25 +20,17 @@ TOTAL              4       2  50.00%
 """
 
 
-def test_show__format_text__long_option():
+def test_show__format_text():
     from pycobertura.cli import show
 
     runner = CliRunner()
-    result = runner.invoke(show, ['tests/dummy.original.xml', '--format', 'text'])
-    assert result.output == """\
-Name           Stmts    Miss  Cover    Missing
------------  -------  ------  -------  ---------
-dummy/dummy        4       2  50.00%   2, 5
-TOTAL              4       2  50.00%
-"""
-
-
-def test_show__format_text__short_option():
-    from pycobertura.cli import show
-
-    runner = CliRunner()
-    result = runner.invoke(show, ['tests/dummy.original.xml', '-f', 'text'])
-    assert result.output == """\
+    for opt in ('-f', '--format'):
+        result = runner.invoke(
+            show,
+            ['tests/dummy.original.xml', opt, 'text'],
+            catch_exceptions=False
+        )
+        assert result.output == """\
 Name           Stmts    Miss  Cover    Missing
 -----------  -------  ------  -------  ---------
 dummy/dummy        4       2  50.00%   2, 5
@@ -44,22 +42,205 @@ def test_show__format_html():
     from pycobertura.cli import show
 
     runner = CliRunner()
-    result = runner.invoke(show, ['tests/dummy.original.xml', '--format', 'html'])
+    result = runner.invoke(show, [
+        'tests/dummy.original.xml', '--format', 'html'
+    ], catch_exceptions=False)
     assert result.output.startswith('<html>')
 
 
-def test_diff():
+def test_show__output_to_file():
+    from pycobertura.cli import show
+
+    with open('tests/dummy.original.xml') as f:
+        cobertura_content = f.read()
+
+    runner = CliRunner()
+    for opt in ('-o', '--output'):
+        with runner.isolated_filesystem():
+            with open('cobertura.xml', 'w') as f:
+                f.write(cobertura_content)
+            result = runner.invoke(show, [
+                'cobertura.xml', opt, 'report.out'
+            ], catch_exceptions=False)
+            with open('report.out') as f:
+                report = f.read()
+            assert result.output == ""
+            assert report == """\
+Name           Stmts    Miss  Cover    Missing
+-----------  -------  ------  -------  ---------
+dummy/dummy        4       2  50.00%   2, 5
+TOTAL              4       2  50.00%"""
+
+
+def test_diff__format_default():
     from pycobertura.cli import diff
 
     runner = CliRunner()
     result = runner.invoke(diff, [
-        'tests/dummy.original.xml',
-        'tests/dummy.with-dummy2-full-cov.xml'
-    ])
+        'tests/dummy.with-dummy2-better-cov.xml',
+        'tests/dummy.with-dummy2-better-and-worse.xml',
+    ], catch_exceptions=False)
+    # FIXME: Fails in PY2, requires click>=4.x to pass
+    if not PY2:
+        assert result.output == """\
+Name          Stmts    Miss    Cover    Missing
+------------  -------  ------  -------  ---------
+dummy/dummy   -        +1      -25.00%  \x1b[31m+5\x1b[39m
+dummy/dummy2  -        -1      +50.00%  \x1b[32m-2\x1b[39m
+TOTAL         -        -       -
+"""
+    else:
+        assert result.output == """\
+Name          Stmts    Miss    Cover    Missing
+------------  -------  ------  -------  ---------
+dummy/dummy   -        +1      -25.00%  +5
+dummy/dummy2  -        -1      +50.00%  -2
+TOTAL         -        -       -
+"""
+
+
+def test_diff__format_text():
+    from pycobertura.cli import diff
+
+    runner = CliRunner()
+    for opt in ('-f', '--format'):
+        result = runner.invoke(diff, [
+            opt, 'text',
+            'tests/dummy.with-dummy2-better-cov.xml',
+            'tests/dummy.with-dummy2-better-and-worse.xml',
+        ], catch_exceptions=False)
+        # FIXME: Fails in PY2, requires click>=4.x to pass
+        if not PY2:
+            assert result.output == """\
+Name          Stmts    Miss    Cover    Missing
+------------  -------  ------  -------  ---------
+dummy/dummy   -        +1      -25.00%  \x1b[31m+5\x1b[39m
+dummy/dummy2  -        -1      +50.00%  \x1b[32m-2\x1b[39m
+TOTAL         -        -       -
+"""
+        else:
+            assert result.output == """\
+Name          Stmts    Miss    Cover    Missing
+------------  -------  ------  -------  ---------
+dummy/dummy   -        +1      -25.00%  +5
+dummy/dummy2  -        -1      +50.00%  -2
+TOTAL         -        -       -
+"""
+
+
+def test_diff__output_to_file():
+    from pycobertura.cli import diff
+
+    with open('tests/dummy.with-dummy2-better-cov.xml') as f:
+        cobertura1_content = f.read()
+
+    with open('tests/dummy.with-dummy2-better-and-worse.xml') as f:
+        cobertura2_content = f.read()
+
+    runner = CliRunner()
+
+    for opt in ('-o', '--output'):
+        with runner.isolated_filesystem():
+
+            with open('cobertura1.xml', 'w') as f:
+                f.write(cobertura1_content)
+
+            with open('cobertura2.xml', 'w') as f:
+                f.write(cobertura2_content)
+
+            result = runner.invoke(diff, [
+                'cobertura1.xml',
+                'cobertura2.xml',
+                opt, 'report.out'
+            ], catch_exceptions=False)
+            with open('report.out') as f:
+                report = f.read()
+            assert result.output == ""
+            assert report == """\
+Name          Stmts    Miss    Cover    Missing
+------------  -------  ------  -------  ---------
+dummy/dummy   -        +1      -25.00%  +5
+dummy/dummy2  -        -1      +50.00%  -2
+TOTAL         -        -       -"""
+
+
+# FIXME: when Click 4 is available, uncomment this.
+#def test_diff__format_text__with_color():
+#    from pycobertura.cli import diff
+#
+#    runner = CliRunner()
+#    result = runner.invoke(diff, [
+#        '--color',
+#        'tests/dummy.with-dummy2-better-cov.xml',
+#        'tests/dummy.with-dummy2-better-and-worse.xml',
+#    ], catch_exceptions=False)
+#    assert result.output == """\
+#Name          Stmts    Miss    Cover    Missing
+#------------  -------  ------  -------  ---------
+#dummy/dummy   -        +1      -25.00%  \x1b[31m+5\x1b[39m
+#dummy/dummy2  -        -1      +50.00%  \x1b[32m-2\x1b[39m
+#TOTAL         -        -       -
+#"""
+
+
+def test_diff__format_html():
+    from pycobertura.cli import diff
+
+    runner = CliRunner()
+    result = runner.invoke(diff, [
+        '--format', 'html',
+        'tests/dummy.with-dummy2-better-cov.xml',
+        'tests/dummy.with-dummy2-better-and-worse.xml',
+    ], catch_exceptions=False)
     assert result.output == """\
-Name          Stmts    Miss    Cover     Missing
-------------  -------  ------  --------  ---------
-dummy/dummy   -        -2      +50.00%   -2, -5
-dummy/dummy2  +2       -       +100.00%
-TOTAL         +2       -2      +50.00%
+<html>
+  <head>
+    <title>pycobertura report</title>
+    <meta charset="UTF-8">
+    <style>
+.red {color: red}
+.green {color: green}
+    </style>
+  </head>
+  <body>
+    <table>
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Stmts</th>
+          <th>Miss</th>
+          <th>Cover</th>
+          <th>Missing</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>dummy/dummy</td>
+          <td>-</td>
+          <td>+1</td>
+          <td>-25.00%</td>
+          <td><span class="red">+5</span>
+          </td>
+        </tr>
+        <tr>
+          <td>dummy/dummy2</td>
+          <td>-</td>
+          <td>-1</td>
+          <td>+50.00%</td>
+          <td><span class="green">-2</span>
+          </td>
+        </tr>
+      </tbody>
+      <tfoot>
+        <tr>
+          <td>TOTAL</td>
+          <td>-</td>
+          <td>-</td>
+          <td>-</td>
+          <td></td>
+        </tr>
+      </tfoot>
+    </table>
+  </body>
+</html>
 """

--- a/tests/test_reporters.py
+++ b/tests/test_reporters.py
@@ -198,42 +198,7 @@ dummy/dummy2  -        -1      +50.00%  -2
 TOTAL         -        -       -"""
 
 
-@mock.patch('pycobertura.utils.sys.stdout.isatty', return_value=True)
-def test_text_report_delta__colorize_for_tty(mock_tty):
-    from pycobertura.reporters import TextReporterDelta
-
-    cobertura1 = make_cobertura('tests/dummy.with-dummy2-better-cov.xml')
-    cobertura2 = make_cobertura('tests/dummy.with-dummy2-better-and-worse.xml')
-
-    report_delta = TextReporterDelta(cobertura1, cobertura2)
-
-    assert report_delta.generate() == """\
-Name          Stmts    Miss    Cover    Missing
-------------  -------  ------  -------  ---------
-dummy/dummy   -        +1      -25.00%  \x1b[31m+5\x1b[39m
-dummy/dummy2  -        -1      +50.00%  \x1b[32m-2\x1b[39m
-TOTAL         -        -       -"""
-
-
-@mock.patch('pycobertura.utils.sys.stdout.isatty', return_value=False)
-def test_text_report_delta__no_colorize_for_non_tty(mock_tty):
-    from pycobertura.reporters import TextReporterDelta
-
-    cobertura1 = make_cobertura('tests/dummy.with-dummy2-better-cov.xml')
-    cobertura2 = make_cobertura('tests/dummy.with-dummy2-better-and-worse.xml')
-
-    report_delta = TextReporterDelta(cobertura1, cobertura2)
-
-    assert report_delta.generate() == """\
-Name          Stmts    Miss    Cover    Missing
-------------  -------  ------  -------  ---------
-dummy/dummy   -        +1      -25.00%  +5
-dummy/dummy2  -        -1      +50.00%  -2
-TOTAL         -        -       -"""
-
-
-@mock.patch('pycobertura.utils.sys.stdout.isatty', return_value=True)
-def test_text_report_delta__force_colorize_when_tty_is_true(mock_tty):
+def test_text_report_delta__colorize_True():
     from pycobertura.reporters import TextReporterDelta
 
     cobertura1 = make_cobertura('tests/dummy.with-dummy2-better-cov.xml')
@@ -249,42 +214,7 @@ dummy/dummy2  -        -1      +50.00%  \x1b[32m-2\x1b[39m
 TOTAL         -        -       -"""
 
 
-@mock.patch('pycobertura.utils.sys.stdout.isatty', return_value=False)
-def test_text_report_delta__force_colorize_when_tty_is_false(mock_tty):
-    from pycobertura.reporters import TextReporterDelta
-
-    cobertura1 = make_cobertura('tests/dummy.with-dummy2-better-cov.xml')
-    cobertura2 = make_cobertura('tests/dummy.with-dummy2-better-and-worse.xml')
-
-    report_delta = TextReporterDelta(cobertura1, cobertura2, color=True)
-
-    assert report_delta.generate() == """\
-Name          Stmts    Miss    Cover    Missing
-------------  -------  ------  -------  ---------
-dummy/dummy   -        +1      -25.00%  \x1b[31m+5\x1b[39m
-dummy/dummy2  -        -1      +50.00%  \x1b[32m-2\x1b[39m
-TOTAL         -        -       -"""
-
-
-@mock.patch('pycobertura.utils.sys.stdout.isatty', return_value=True)
-def test_text_report_delta__force_no_colorize_when_tty_is_true(mock_tty):
-    from pycobertura.reporters import TextReporterDelta
-
-    cobertura1 = make_cobertura('tests/dummy.with-dummy2-better-cov.xml')
-    cobertura2 = make_cobertura('tests/dummy.with-dummy2-better-and-worse.xml')
-
-    report_delta = TextReporterDelta(cobertura1, cobertura2, color=False)
-
-    assert report_delta.generate() == """\
-Name          Stmts    Miss    Cover    Missing
-------------  -------  ------  -------  ---------
-dummy/dummy   -        +1      -25.00%  +5
-dummy/dummy2  -        -1      +50.00%  -2
-TOTAL         -        -       -"""
-
-
-@mock.patch('pycobertura.utils.sys.stdout.isatty', return_value=False)
-def test_text_report_delta__force_no_colorize_when_tty_is_false(mock_tty):
+def test_text_report_delta__colorize_False():
     from pycobertura.reporters import TextReporterDelta
 
     cobertura1 = make_cobertura('tests/dummy.with-dummy2-better-cov.xml')


### PR DESCRIPTION
I can't get the tests to pass on both PY3 and PY2 because of how `click.echo()` has conditional logic based on the Python version. Only PY3 passes currently because it's doing the expected thing. Version `click>=4` will make things work as expected when it gets released.

https://twitter.com/alexconrad/status/542587076563464192
