### PR TITLE
py26 compat: switch XML parser to `lxml`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* fix py26 compatibility by switching the XML parser to `lxml` which has a more
+  predictible behavior when used across all Python versions.
+
 ## 0.2.0 (2014-12-10)
 
 * apply Skeleton 2.0 theme to html output

--- a/pycobertura/cobertura.py
+++ b/pycobertura/cobertura.py
@@ -1,6 +1,6 @@
 import os
 
-from xml.etree import ElementTree as ET
+import lxml.etree as ET
 
 
 class Cobertura(object):

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     packages=find_packages(exclude=['tests']),
     long_description='%s\n\n%s' % (README, CHANGES),
     setup_requires=['setuptools_git'],
-    install_requires=['click', 'colorama', 'jinja2', 'tabulate'],
+    install_requires=['click', 'colorama', 'jinja2', 'lxml', 'tabulate'],
     classifiers=[
         "Topic :: Software Development :: Libraries :: Python Modules",
         "License :: OSI Approved :: MIT License",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,7 +1,7 @@
 from click.testing import CliRunner
 import sys
 
-PY2 = sys.version_info.major == 2
+PY2 = sys.version_info[0] == 2
 
 
 def test_show__format_default():

--- a/tests/test_cobertura.py
+++ b/tests/test_cobertura.py
@@ -1,6 +1,6 @@
 import mock
 
-import xml.etree.ElementTree as ET
+import lxml.etree as ET
 
 
 SOURCE_FILE = 'tests/cobertura.xml'
@@ -19,7 +19,7 @@ def test_parse_string():
         xml = f.read()
 
     cobertura = Cobertura(xml)
-    assert isinstance(cobertura.xml, ET.Element)
+    assert isinstance(cobertura.xml, ET._Element)
 
 
 def test_parse_fileobj():
@@ -27,7 +27,7 @@ def test_parse_fileobj():
 
     with open(SOURCE_FILE) as f:
         cobertura = Cobertura(f)
-    assert isinstance(cobertura.xml, ET.Element)
+    assert isinstance(cobertura.xml, ET._Element)
 
 
 def test_parse_path():


### PR DESCRIPTION
fix py26 compatibility by switching the XML parser to `lxml` which has a more
predictible behavior when used across all Python versions.

Fixes #12 
