### PR TITLE
Be less strict about where `class` elements are found

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 # Release Notes
 
 ## Unreleased
+* Fix a `IndexError: list index out of range` error by being less specific about where to find `class` elements in the Cobertura report.
 
 ## 0.10.0 (2016-09-27)
 * BACKWARDS INCOMPATIBLE: when a source file is not found in disk pycobertura

--- a/pycobertura/cobertura.py
+++ b/pycobertura/cobertura.py
@@ -75,7 +75,7 @@ class Cobertura(object):
 
     @memoize
     def _get_class_element_by_filename(self, filename):
-        syntax = "./packages/package/classes/class[@filename='%s'][1]" % (
+        syntax = "./packages//class[@filename='%s'][1]" % (
             filename
         )
         return self.xml.xpath(syntax)[0]

--- a/tests/cobertura-generated-by-istanbul-from-coffeescript.xml
+++ b/tests/cobertura-generated-by-istanbul-from-coffeescript.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" ?>
+<!DOCTYPE coverage SYSTEM "http://cobertura.sourceforge.net/xml/coverage-04.dtd">
+<coverage lines-valid="8" lines-covered="7" line-rate="0.875" branches-valid="2" branches-covered="1" branch-rate="0.5" timestamp="1514593481526" complexity="0" version="0.1">
+  <sources>
+    <source>/Users/aconrad/lever/coverage-test</source>
+  </sources>
+  <packages>
+    <class name="app.coffee" filename="app.coffee" line-rate="0.875" branch-rate="0.5">
+      <methods>
+        <method name="(anonymous_1)" hits="1" signature="()V">
+          <lines>
+            <line number="6" hits="1"/>
+          </lines>
+        </method>
+      </methods>
+      <lines>
+        <line number="1" hits="1" branch="false"/>
+        <line number="2" hits="1" branch="false"/>
+        <line number="4" hits="1" branch="false"/>
+        <line number="6" hits="1" branch="false"/>
+        <line number="7" hits="1" branch="true" condition-coverage="50% (1/2)"/>
+        <line number="8" hits="1" branch="false"/>
+        <line number="10" hits="0" branch="false"/>
+        <line number="11" hits="1" branch="false"/>
+      </lines>
+    </class>
+  </packages>
+</coverage>

--- a/tests/test_cobertura.py
+++ b/tests/test_cobertura.py
@@ -80,16 +80,22 @@ def test_list_packages():
     assert packages == ['', 'search']
 
 
-def test_list_classes():
-    cobertura = make_cobertura()
-
-    classes = cobertura.files()
-    assert classes == [
+@pytest.mark.parametrize("report, expected", [
+    ('tests/cobertura-generated-by-istanbul-from-coffeescript.xml', [
+        'app.coffee'
+    ]),
+    ('tests/cobertura.xml', [
         'Main.java',
         'search/BinarySearch.java',
         'search/ISortedArraySearch.java',
         'search/LinearSearch.java'
-    ]
+    ])
+])
+def test_list_classes(report, expected):
+    cobertura = make_cobertura(xml=report)
+
+    classes = cobertura.files()
+    assert classes == expected
 
 
 def test_hit_lines__by_iterating_over_classes():


### PR DESCRIPTION
Here's a sample of a coverage report generated by mocha / istanbul (nyc) / coffeescript.

The `class` elements are not necessarily under `/packages/package/classes/class`.

```xml
<?xml version="1.0" ?>
<!DOCTYPE coverage SYSTEM "http://cobertura.sourceforge.net/xml/coverage-04.dtd">
<coverage lines-valid="8" lines-covered="7" line-rate="0.875" branches-valid="2" branches-covered="1" branch-rate="0.5" timestamp="1514593481526" complexity="0" version="0.1">
  <sources>
    <source>/Users/aconrad/lever/coverage-test</source>
  </sources>
  <packages>
    <class name="app.coffee" filename="app.coffee" line-rate="0.875" branch-rate="0.5">
      <methods>
        <method name="(anonymous_1)" hits="1" signature="()V">
          <lines>
            <line number="6" hits="1"/>
          </lines>
        </method>
      </methods>
      <lines>
        <line number="1" hits="1" branch="false"/>
        <line number="2" hits="1" branch="false"/>
        <line number="4" hits="1" branch="false"/>
        <line number="6" hits="1" branch="false"/>
        <line number="7" hits="1" branch="true" condition-coverage="50% (1/2)"/>
        <line number="8" hits="1" branch="false"/>
        <line number="10" hits="0" branch="false"/>
        <line number="11" hits="1" branch="false"/>
      </lines>
    </class>
  </packages>
</coverage>
```

... and it would raise the following error:

```python
Traceback (most recent call last):
  File "/Users/aconrad/.virtualenvs/impl-specialist/bin/pycobertura", line 11, in <module>
    sys.exit(pycobertura())
  File "/Users/aconrad/.virtualenvs/impl-specialist/lib/python2.7/site-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/Users/aconrad/.virtualenvs/impl-specialist/lib/python2.7/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/Users/aconrad/.virtualenvs/impl-specialist/lib/python2.7/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/aconrad/.virtualenvs/impl-specialist/lib/python2.7/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/aconrad/.virtualenvs/impl-specialist/lib/python2.7/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/Users/aconrad/.virtualenvs/impl-specialist/lib/python2.7/site-packages/pycobertura/cli.py", line 168, in diff
    report = reporter.generate()
  File "/Users/aconrad/.virtualenvs/impl-specialist/lib/python2.7/site-packages/pycobertura/reporters.py", line 229, in generate
    lines = self.get_report_lines()
  File "/Users/aconrad/.virtualenvs/impl-specialist/lib/python2.7/site-packages/pycobertura/reporters.py", line 167, in get_report_lines
    file_row = self.get_file_row(filename)
  File "/Users/aconrad/.virtualenvs/impl-specialist/lib/python2.7/site-packages/pycobertura/reporters.py", line 133, in get_file_row
    self.differ.diff_total_statements(filename),
  File "/Users/aconrad/.virtualenvs/impl-specialist/lib/python2.7/site-packages/pycobertura/cobertura.py", line 328, in diff_total_statements
    return int(self._diff_attr('total_statements', filename))
  File "/Users/aconrad/.virtualenvs/impl-specialist/lib/python2.7/site-packages/pycobertura/cobertura.py", line 318, in _diff_attr
    count1 = method(filename)
  File "/Users/aconrad/.virtualenvs/impl-specialist/lib/python2.7/site-packages/pycobertura/cobertura.py", line 223, in total_statements
    statements = self._get_lines_by_filename(filename)
  File "/Users/aconrad/.virtualenvs/impl-specialist/lib/python2.7/site-packages/pycobertura/utils.py", line 14, in __call__
    return self.cache_get(self.memoized, args, lambda: self.func(*args))
  File "/Users/aconrad/.virtualenvs/impl-specialist/lib/python2.7/site-packages/pycobertura/utils.py", line 26, in cache_get
    v = cache[key] = func()
  File "/Users/aconrad/.virtualenvs/impl-specialist/lib/python2.7/site-packages/pycobertura/utils.py", line 14, in <lambda>
    return self.cache_get(self.memoized, args, lambda: self.func(*args))
  File "/Users/aconrad/.virtualenvs/impl-specialist/lib/python2.7/site-packages/pycobertura/cobertura.py", line 86, in _get_lines_by_filename
    el = self._get_class_element_by_filename(filename)
  File "/Users/aconrad/.virtualenvs/impl-specialist/lib/python2.7/site-packages/pycobertura/utils.py", line 14, in __call__
    return self.cache_get(self.memoized, args, lambda: self.func(*args))
  File "/Users/aconrad/.virtualenvs/impl-specialist/lib/python2.7/site-packages/pycobertura/utils.py", line 26, in cache_get
    v = cache[key] = func()
  File "/Users/aconrad/.virtualenvs/impl-specialist/lib/python2.7/site-packages/pycobertura/utils.py", line 14, in <lambda>
    return self.cache_get(self.memoized, args, lambda: self.func(*args))
  File "/Users/aconrad/.virtualenvs/impl-specialist/lib/python2.7/site-packages/pycobertura/cobertura.py", line 82, in _get_class_element_by_filename
    return self.xml.xpath(syntax)[0]
IndexError: list index out of range
```