### PR TITLE
Drop Python 2.6 builds in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 
 sudo: false
 env:
-    - TOXENV=py26
     - TOXENV=py27
     - TOXENV=py34
     - TOXENV=pep8


### PR DESCRIPTION
It seems that the build is now failing for Python 2.6 because the interpreter is not found by Tox. After a quick search I couldn't find anything relevant with Travis dropping Python 2.6 support but my guess is that travis might be running a newer version of ubuntu for its build environment and that Python 2.6 is not longer installed by default.

I don't want to spend time figuring out how to re-enable Python 2.6 in travis so let's just drop Python 2.6 support altogether.