### PR TITLE
cobertura: avoid duplicate file names in files()

### DIFF
--- a/pycobertura/cobertura.py
+++ b/pycobertura/cobertura.py
@@ -234,8 +234,18 @@ class Cobertura(object):
         """
         Return the list of available files in the coverage report.
         """
-        return list(sorted(set(
-            [el.attrib['filename'] for el in self.xml.xpath("//class")])))
+        # maybe replace with a trie at some point? see has_file FIXME
+        already_seen = set()
+        filenames = []
+
+        for el in self.xml.xpath("//class"):
+            filename = el.attrib['filename']
+            if filename in already_seen:
+                continue
+            already_seen.add(filename)
+            filenames.append(filename)
+
+        return filenames
 
     def has_file(self, filename):
         """

--- a/pycobertura/cobertura.py
+++ b/pycobertura/cobertura.py
@@ -234,7 +234,8 @@ class Cobertura(object):
         """
         Return the list of available files in the coverage report.
         """
-        return list(sorted(set([el.attrib['filename'] for el in self.xml.xpath("//class")])))
+        return list(sorted(set(
+            [el.attrib['filename'] for el in self.xml.xpath("//class")])))
 
     def has_file(self, filename):
         """

--- a/pycobertura/cobertura.py
+++ b/pycobertura/cobertura.py
@@ -234,7 +234,7 @@ class Cobertura(object):
         """
         Return the list of available files in the coverage report.
         """
-        return [el.attrib['filename'] for el in self.xml.xpath("//class")]
+        return list(set([el.attrib['filename'] for el in self.xml.xpath("//class")]))
 
     def has_file(self, filename):
         """

--- a/pycobertura/cobertura.py
+++ b/pycobertura/cobertura.py
@@ -234,7 +234,7 @@ class Cobertura(object):
         """
         Return the list of available files in the coverage report.
         """
-        return list(set([el.attrib['filename'] for el in self.xml.xpath("//class")]))
+        return list(sorted(set([el.attrib['filename'] for el in self.xml.xpath("//class")])))
 
     def has_file(self, filename):
         """

--- a/tests/cobertura.xml
+++ b/tests/cobertura.xml
@@ -49,6 +49,24 @@
 						<line number="30" hits="3" branch="false"/>
 					</lines>
 				</class>
+				<class name="Main$Helper" filename="Main.java" line-rate="1.0" branch-rate="1.0" complexity="1.0">
+					<methods>
+						<method name="help" signature="([Ljava/lang/String;)V" line-rate="1.0" branch-rate="1.0">
+							<lines>
+								<line number="31" hits="3" branch="false"/>
+								<line number="32" hits="3" branch="false"/>
+								<line number="33" hits="3" branch="false"/>
+								<line number="34" hits="3" branch="false"/>
+							</lines>
+						</method>
+					</methods>
+					<lines>
+						<line number="31" hits="3" branch="false"/>
+						<line number="32" hits="3" branch="false"/>
+						<line number="33" hits="3" branch="false"/>
+						<line number="34" hits="3" branch="false"/>
+					</lines>
+				</class>
 			</classes>
 		</package>
 		<package name="search" line-rate="0.8421052631578947" branch-rate="0.75" complexity="3.25">


### PR DESCRIPTION
some coverage reports include metrics for multiple classes within the same file. without this change, redundant rows are generated for such reports.