### PR TITLE
Calculate the correct line rate for diffs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,12 @@
 # Release Notes
 
 ## Unreleased
+* Calculate the correct line rate for diffs (#83)
+  Previously `CoberturaDiff.diff_line_rate` with no filename argument would
+  total up the different line rate changes from all of the modified files,
+  which is not the correct difference in line rates between all files.  Now
+  the difference in line rate from the two reports objects will be directly
+  used if no argument is passed. (@borgstrom)
 
 ## 0.10.3 (2018-03-20)
 * Update author/repository info

--- a/pycobertura/cobertura.py
+++ b/pycobertura/cobertura.py
@@ -344,7 +344,9 @@ class CoberturaDiff(object):
         return int(self._diff_attr('total_hits', filename))
 
     def diff_line_rate(self, filename=None):
-        return self._diff_attr('line_rate', filename)
+        if filename is not None:
+            return self._diff_attr('line_rate', filename)
+        return self.cobertura2.line_rate() - self.cobertura1.line_rate()
 
     def diff_missed_lines(self, filename):
         """

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -99,7 +99,7 @@ Filename         Stmts      Miss  Cover    Missing
 dummy/dummy.py   -            \x1b[32m-2\x1b[39m  +40.00%  \x1b[32m-5\x1b[39m, \x1b[32m-6\x1b[39m
 dummy/dummy2.py  +2           \x1b[31m+1\x1b[39m  -25.00%  \x1b[32m-2\x1b[39m, \x1b[32m-4\x1b[39m, \x1b[31m+5\x1b[39m
 dummy/dummy3.py  +2           \x1b[31m+2\x1b[39m  -        \x1b[31m+1\x1b[39m, \x1b[31m+2\x1b[39m
-TOTAL            +4           \x1b[31m+1\x1b[39m  +15.00%
+TOTAL            +4           \x1b[31m+1\x1b[39m  +31.06%
 """
     assert result.exit_code == ExitCodes.COVERAGE_WORSENED
 
@@ -120,7 +120,7 @@ Filename         Stmts      Miss  Cover    Missing
 dummy/dummy.py   -            \x1b[32m-2\x1b[39m  +40.00%  \x1b[32m-5\x1b[39m, \x1b[32m-6\x1b[39m
 dummy/dummy2.py  +2           \x1b[31m+1\x1b[39m  -25.00%  \x1b[32m-2\x1b[39m, \x1b[32m-4\x1b[39m, \x1b[31m+5\x1b[39m
 dummy/dummy3.py  +2           \x1b[31m+2\x1b[39m  -        \x1b[31m+1\x1b[39m, \x1b[31m+2\x1b[39m
-TOTAL            +4           \x1b[31m+1\x1b[39m  +15.00%
+TOTAL            +4           \x1b[31m+1\x1b[39m  +31.06%
 """
     assert result.exit_code == ExitCodes.COVERAGE_WORSENED
 
@@ -146,7 +146,7 @@ Filename         Stmts      Miss  Cover    Missing
 dummy/dummy.py   -            -2  +40.00%  -5, -6
 dummy/dummy2.py  +2           +1  -25.00%  -2, -4, +5
 dummy/dummy3.py  +2           +2  -        +1, +2
-TOTAL            +4           +1  +15.00%"""
+TOTAL            +4           +1  +31.06%"""
     assert result.exit_code == ExitCodes.COVERAGE_WORSENED
 
 
@@ -170,7 +170,7 @@ Filename         Stmts      Miss  Cover    Missing
 dummy/dummy.py   -            \x1b[32m-2\x1b[39m  +40.00%  \x1b[32m-5\x1b[39m, \x1b[32m-6\x1b[39m
 dummy/dummy2.py  +2           \x1b[31m+1\x1b[39m  -25.00%  \x1b[32m-2\x1b[39m, \x1b[32m-4\x1b[39m, \x1b[31m+5\x1b[39m
 dummy/dummy3.py  +2           \x1b[31m+2\x1b[39m  -        \x1b[31m+1\x1b[39m, \x1b[31m+2\x1b[39m
-TOTAL            +4           \x1b[31m+1\x1b[39m  +15.00%"""
+TOTAL            +4           \x1b[31m+1\x1b[39m  +31.06%"""
     assert result.exit_code == ExitCodes.COVERAGE_WORSENED
 
 
@@ -189,7 +189,7 @@ Filename         Stmts      Miss  Cover    Missing
 dummy/dummy.py   -            \x1b[32m-2\x1b[39m  +40.00%  \x1b[32m-5\x1b[39m, \x1b[32m-6\x1b[39m
 dummy/dummy2.py  +2           \x1b[31m+1\x1b[39m  -25.00%  \x1b[32m-2\x1b[39m, \x1b[32m-4\x1b[39m, \x1b[31m+5\x1b[39m
 dummy/dummy3.py  +2           \x1b[31m+2\x1b[39m  -        \x1b[31m+1\x1b[39m, \x1b[31m+2\x1b[39m
-TOTAL            +4           \x1b[31m+1\x1b[39m  +15.00%
+TOTAL            +4           \x1b[31m+1\x1b[39m  +31.06%
 """
     assert result.exit_code == ExitCodes.COVERAGE_WORSENED
 
@@ -209,7 +209,7 @@ Filename         Stmts      Miss  Cover    Missing
 dummy/dummy.py   -            -2  +40.00%  -5, -6
 dummy/dummy2.py  +2           +1  -25.00%  -2, -4, +5
 dummy/dummy3.py  +2           +2  -        +1, +2
-TOTAL            +4           +1  +15.00%
+TOTAL            +4           +1  +31.06%
 """
     assert result.exit_code == ExitCodes.COVERAGE_WORSENED
 

--- a/tests/test_cobertura_diff.py
+++ b/tests/test_cobertura_diff.py
@@ -73,7 +73,7 @@ def test_diff_line_rate():
     cobertura2 = make_cobertura('tests/dummy.source2/coverage.xml')
     differ = CoberturaDiff(cobertura1, cobertura2)
 
-    assert differ.diff_line_rate() == 0.15000000000000002
+    assert differ.diff_line_rate() == 0.31059999999999993
 
 
 def test_diff_line_rate_by_class_file():

--- a/tests/test_reporters.py
+++ b/tests/test_reporters.py
@@ -69,7 +69,7 @@ Filename         Stmts      Miss  Cover    Missing
 dummy/dummy.py   -            \x1b[32m-2\x1b[39m  +40.00%  \x1b[32m-5\x1b[39m, \x1b[32m-6\x1b[39m
 dummy/dummy2.py  +2           \x1b[31m+1\x1b[39m  -25.00%  \x1b[32m-2\x1b[39m, \x1b[32m-4\x1b[39m, \x1b[31m+5\x1b[39m
 dummy/dummy3.py  +2           \x1b[31m+2\x1b[39m  -        \x1b[31m+1\x1b[39m, \x1b[31m+2\x1b[39m
-TOTAL            +4           \x1b[31m+1\x1b[39m  +15.00%"""
+TOTAL            +4           \x1b[31m+1\x1b[39m  +31.06%"""
 
 
 def test_text_report_delta__colorize_True__with_missing_range():
@@ -86,7 +86,7 @@ Filename         Stmts      Miss  Cover    Missing
 dummy/dummy.py   -            \x1b[32m-2\x1b[39m  +40.00%  \x1b[32m-5\x1b[39m, \x1b[32m-6\x1b[39m
 dummy/dummy2.py  +2           \x1b[31m+1\x1b[39m  -25.00%  \x1b[32m-2\x1b[39m, \x1b[32m-4\x1b[39m, \x1b[31m+5\x1b[39m
 dummy/dummy3.py  +2           \x1b[31m+2\x1b[39m  -        \x1b[31m+1\x1b[39m, \x1b[31m+2\x1b[39m
-TOTAL            +4           \x1b[31m+1\x1b[39m  +15.00%"""
+TOTAL            +4           \x1b[31m+1\x1b[39m  +31.06%"""
 
 
 def test_text_report_delta__colorize_False():
@@ -103,7 +103,7 @@ Filename         Stmts      Miss  Cover    Missing
 dummy/dummy.py   -            -2  +40.00%  -5, -6
 dummy/dummy2.py  +2           +1  -25.00%  -2, -4, +5
 dummy/dummy3.py  +2           +2  -        +1, +2
-TOTAL            +4           +1  +15.00%"""
+TOTAL            +4           +1  +31.06%"""
 
 
 def test_html_report():
@@ -249,7 +249,7 @@ Filename         Stmts      Miss  Cover
 dummy/dummy.py   -            -2  +40.00%
 dummy/dummy2.py  +2           +1  -25.00%
 dummy/dummy3.py  +2           +2  -
-TOTAL            +4           +1  +15.00%"""
+TOTAL            +4           +1  +31.06%"""
 
 
 def test_html_report_delta__no_source():
@@ -305,7 +305,7 @@ def test_html_report_delta__no_source():
             <td>TOTAL</td>
             <td>+4</td>
             <td><span class="red">+1</span></td>
-            <td>+15.00%</td>
+            <td>+31.06%</td>
           </tr>
         </tfoot>
       </table>
@@ -376,7 +376,7 @@ def test_html_report_delta():
             <td>TOTAL</td>
             <td>+4</td>
             <td><span class="red">+1</span></td>
-            <td>+15.00%</td>
+            <td>+31.06%</td>
             <td></td>
           </tr>
         </tfoot>


### PR DESCRIPTION
Hi 👋 , thanks for building pycobertura!

While integrating into a CI process I noticed that the line rate produced by the differ tool is incorrect.  For example:

```
$ pycobertura diff --source1 build/change-target --source2 . build/change-target-metrics/coverage.xml build/metrics/coverage.xml
<file>  -13      -7      -2.57%    -3, -4, -17, +22, +23, +25, +38, +40, +42, +43, +47, +51, +55
<file>  +43      +10     +76.74%   -1, -3, -5, -6, -7, -9, -12, -18, -19, -21, -22, -23, +24, +25, +26, -28, -29, -35, -36, +41, +42, -46, -49, -50, -52, +53, +54, -56, -57, -58, -60, -63, -64, -65, -66, +67, +68, +69, -71, -74, -75, -78, -79
<file>  +1       -       -         -14, -22, -27, -28, -29, -30, -31, -32
<file>  -        -       -         -12, -15, -16, -20, -24, -28, -31, -32, -33, -34, -35, -36
<file>  +1       -       -         -10
<file>  -        +4      -36.36%   -10, +11, +13, +14, +15
<file>  +3       -       +100.00%  -2, -3, -5
<file>  +4       -       -         -2, -3, -4, -7, -8, -18
<file>  -        +1      -10.00%   +10
<file>  -        +2      -2.02%    +80, +83
TOTAL   +39      +10     +125.79%
```

125.79% change doesn't make sense here (or is even mathematically possible!).  Looking at the line rates of the two different reports the 10 new uncovered lines should result in a `-1.08%` change to total coverage.

```
In [1]: from pycobertura import Cobertura, CoberturaDiff

In [2]: c1 = Cobertura('build/change-target-metrics/coverage.xml', source='build/change-target')

In [3]: c2 = Cobertura('build/metrics/coverage.xml', source='.')

In [4]: c2.line_rate()
Out[4]: 0.7464

In [5]: c1.line_rate()
Out[5]: 0.7572
```

This PR changes the logic for `CoberturaDiff.diff_line_rate` so that if you don't pass a filename it will just use the the `Cobertura.line_rate` method directly.