### PR TITLE
Fix for excessive memory usage caused by memoize

### DIFF
--- a/pycobertura/utils.py
+++ b/pycobertura/utils.py
@@ -1,30 +1,48 @@
 import colorama
 import difflib
-import functools
+from functools import partial
 
 
-# https://gist.github.com/267733/8f5d2e3576b6a6f221f6fb7e2e10d395ad7303f9
+# Recipie from https://github.com/ActiveState/
+# code/recipes/Python/577452_memoize_decorator_instance/recipe-577452.py
 class memoize(object):
+    """cache the return value of a method
+
+    This class is meant to be used as a decorator of methods. The return value
+    from a given method invocation will be cached on the instance whose method
+    was invoked. All arguments passed to a method decorated with memoize must
+    be hashable.
+
+    If a memoized method is invoked directly on its class the result will not
+    be cached. Instead the method will be invoked like a static method:
+    class Obj(object):
+        @memoize
+        def add_to(self, arg):
+            return self + arg
+    Obj.add_to(1) # not enough arguments
+    Obj.add_to(1, 2) # returns 3, result is not cached
+    """
+
     def __init__(self, func):
         self.func = func
-        self.memoized = {}
-        self.method_cache = {}
 
-    def __call__(self, *args):
-        return self.cache_get(self.memoized, args, lambda: self.func(*args))
+    def __get__(self, obj, objtype=None):
+        if obj is None:
+            return self.func
+        return partial(self, obj)
 
-    def __get__(self, obj, objtype):
-        return self.cache_get(
-            self.method_cache, obj,
-            lambda: self.__class__(functools.partial(self.func, obj))
-        )
-
-    def cache_get(self, cache, key, func):
+    def __call__(self, *args, **kw):
+        obj = args[0]
         try:
-            return cache[key]
+            cache = obj.__cache
+        except AttributeError:
+            cache = obj.__cache = {}
+        key = (self.func, args[1:], frozenset(kw.items()))
+        try:
+            res = cache[key]
         except KeyError:
-            v = cache[key] = func()
-            return v
+            res = cache[key] = self.func(*args, **kw)
+        return res
 
 
 def colorize(text, color):

--- a/pycobertura/utils.py
+++ b/pycobertura/utils.py
@@ -3,7 +3,7 @@ import difflib
 from functools import partial
 
 
-# Recipie from https://github.com/ActiveState/
+# Recipe from https://github.com/ActiveState/
 # code/recipes/Python/577452_memoize_decorator_instance/recipe-577452.py
 class memoize(object):
     """cache the return value of a method


### PR DESCRIPTION
The memoize decorator used was not clearing cache and process running
out of memory when large number of coverage files are parsed.

This changes used a better memoize which clears cache object goes out of
scope.