### PR TITLE
Fix Pytest4.x compatibility error

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,4 @@
-[pytest]
+[tool:pytest]
 norecursedirs = build docs/_build *.egg .tox *.venv tests/dummy*
 addopts =
     # Shows a line for every test


### PR DESCRIPTION
According to pytest docs:

```
[pytest] section in setup.cfg files

Removed in version 4.0.

[pytest] sections in setup.cfg files should now be named [tool:pytest] to
avoid conflicts with other distutils commands.
```