### PR TITLE
feat: a customizable html report

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Let the caller customize the appearance of the HTML report providing a `title`, omitting the rendering of sources by means of the boolean `render_file_sources` and providing an helpful message to the end-users (in place of the sources) by means of the `no_file_sources_message` parameter. Contributed by @nilleb.
+
 ## 0.10.5 (2018-12-11)
 * Use a different `memoize()` implementation so that cached objects can be freed/garbage collected and prevent from running out of memory when processing a lot of cobertura files. Thanks @kannaiah
 

--- a/pycobertura/reporters.py
+++ b/pycobertura/reporters.py
@@ -95,6 +95,9 @@ class TextReporter(Reporter):
 
 class HtmlReporter(TextReporter):
     def __init__(self, *args, **kwargs):
+        self.title = kwargs.pop("title", "pycobertura report")
+        self.inline_sources = kwargs.pop("inline_sources", True)
+        self.sources_message = kwargs.pop('sources_message', None)
         super(HtmlReporter, self).__init__(*args, **kwargs)
 
     def get_source(self, filename):
@@ -110,15 +113,18 @@ class HtmlReporter(TextReporter):
             formatted_lines.append(formatted_row)
 
         sources = []
-        for filename in self.cobertura.files():
-            source = self.get_source(filename)
-            sources.append((filename, source))
+        if self.inline_sources:
+            for filename in self.cobertura.files():
+                source = self.get_source(filename)
+                sources.append((filename, source))
 
         template = env.get_template('html.jinja2')
         return template.render(
+            title=title,
             lines=formatted_lines[:-1],
             footer=formatted_lines[-1],
-            sources=sources
+            sources=sources,
+            sources_message=self.sources_message
         )
 
 

--- a/pycobertura/reporters.py
+++ b/pycobertura/reporters.py
@@ -123,7 +123,7 @@ class HtmlReporter(TextReporter):
 
         template = env.get_template('html.jinja2')
         return template.render(
-            title=title,
+            title=self.title,
             lines=formatted_lines[:-1],
             footer=formatted_lines[-1],
             sources=sources,

--- a/pycobertura/reporters.py
+++ b/pycobertura/reporters.py
@@ -96,8 +96,11 @@ class TextReporter(Reporter):
 class HtmlReporter(TextReporter):
     def __init__(self, *args, **kwargs):
         self.title = kwargs.pop("title", "pycobertura report")
-        self.inline_sources = kwargs.pop("inline_sources", True)
-        self.sources_message = kwargs.pop('sources_message', None)
+        self.render_file_sources = kwargs.pop("render_file_sources", True)
+        self.no_file_sources_message = kwargs.pop(
+            "no_file_sources_message",
+            "Rendering of source files was disabled."
+        )
         super(HtmlReporter, self).__init__(*args, **kwargs)
 
     def get_source(self, filename):
@@ -113,7 +116,7 @@ class HtmlReporter(TextReporter):
             formatted_lines.append(formatted_row)
 
         sources = []
-        if self.inline_sources:
+        if self.render_file_sources:
             for filename in self.cobertura.files():
                 source = self.get_source(filename)
                 sources.append((filename, source))
@@ -124,7 +127,7 @@ class HtmlReporter(TextReporter):
             lines=formatted_lines[:-1],
             footer=formatted_lines[-1],
             sources=sources,
-            sources_message=self.sources_message
+            no_file_sources_message=self.no_file_sources_message
         )
 
 

--- a/pycobertura/templates/html.jinja2
+++ b/pycobertura/templates/html.jinja2
@@ -13,7 +13,7 @@ pre {line-height: 1.3}
   </head>
   <body>
     <div class="container">
-      <h1> {{ title }} </h1>
+      <h1>{{ title }}</h1>
       <table class="u-full-width">
         <thead>
           <tr>
@@ -29,9 +29,9 @@ pre {line-height: 1.3}
           <tr>
             <td>
             {% if sources %}
-                <a href="#{{ line.filename }}">{{ line.filename }}</a>
+              <a href="#{{ line.filename }}">{{ line.filename }}</a>
             {% else %}
-                {{ line.filename }}
+              {{ line.filename }}
             {% endif %}
             </td>
             <td>{{ line.total_statements }}</td>
@@ -58,7 +58,7 @@ pre {line-height: 1.3}
 {{ render_source(source) }}
 {%- endfor %}
 {% else %}
-    {{ sources_message }}
+  <p>{{ no_file_sources_message }}</p>
 {% endif %}
     </div>
   </body>

--- a/pycobertura/templates/html.jinja2
+++ b/pycobertura/templates/html.jinja2
@@ -1,6 +1,6 @@
 <html>
   <head>
-    <title>pycobertura report</title>
+    <title>{{ title }}</title>
     <meta charset="UTF-8">
     <style>
 {% include 'normalize.css' %}
@@ -13,6 +13,7 @@ pre {line-height: 1.3}
   </head>
   <body>
     <div class="container">
+      <h1> {{ title }} </h1>
       <table class="u-full-width">
         <thead>
           <tr>
@@ -26,7 +27,13 @@ pre {line-height: 1.3}
         <tbody>
 {%- for line in lines %}
           <tr>
-            <td><a href="#{{ line.filename }}">{{ line.filename }}</a></td>
+            <td>
+            {% if sources %}
+                <a href="#{{ line.filename }}">{{ line.filename }}</a>
+            {% else %}
+                {{ line.filename }}
+            {% endif %}
+            </td>
             <td>{{ line.total_statements }}</td>
             <td>{{ line.total_misses }}</td>
             <td>{{ line.line_rate }}</td>
@@ -44,11 +51,15 @@ pre {line-height: 1.3}
           </tr>
         </tfoot>
       </table>
+{% if sources %}
 {%- from 'macro.source.jinja2' import render_source -%}
 {%- for filename, source in sources %}
 <h4 id="{{ filename }}">{{ filename }}</h4>
 {{ render_source(source) }}
 {%- endfor %}
+{% else %}
+    {{ sources_message }}
+{% endif %}
     </div>
   </body>
 </html>

--- a/pycobertura/templates/html.jinja2
+++ b/pycobertura/templates/html.jinja2
@@ -27,13 +27,11 @@ pre {line-height: 1.3}
         <tbody>
 {%- for line in lines %}
           <tr>
-            <td>
-            {% if sources %}
-              <a href="#{{ line.filename }}">{{ line.filename }}</a>
-            {% else %}
-              {{ line.filename }}
-            {% endif %}
-            </td>
+            {%- if sources %}
+            <td><a href="#{{ line.filename }}">{{ line.filename }}</a></td>
+            {%- else %}
+            <td>{{ line.filename }}</td>
+            {%- endif %}
             <td>{{ line.total_statements }}</td>
             <td>{{ line.total_misses }}</td>
             <td>{{ line.line_rate }}</td>
@@ -51,15 +49,15 @@ pre {line-height: 1.3}
           </tr>
         </tfoot>
       </table>
-{% if sources %}
+{%- if sources %}
 {%- from 'macro.source.jinja2' import render_source -%}
 {%- for filename, source in sources %}
 <h4 id="{{ filename }}">{{ filename }}</h4>
 {{ render_source(source) }}
 {%- endfor %}
 {% else %}
-  <p>{{ no_file_sources_message }}</p>
-{% endif %}
+<p>{{ no_file_sources_message }}</p>
+{%- endif %}
     </div>
   </body>
 </html>

--- a/tests/test_reporters.py
+++ b/tests/test_reporters.py
@@ -124,6 +124,7 @@ def test_html_report():
   </head>
   <body>
     <div class="container">
+      <h1>pycobertura report</h1>
       <table class="u-full-width">
         <thead>
           <tr>
@@ -230,6 +231,82 @@ def test_html_report():
     </tr>
   </tbody>
 </table>
+
+    </div>
+  </body>
+</html>"""
+
+
+def test_html_report__no_source_files_message():
+    from pycobertura.reporters import HtmlReporter
+
+    cobertura = make_cobertura()
+    report = HtmlReporter(cobertura, title="test report", render_file_sources=False)
+    html_output = report.generate()
+
+    assert "normalize.css" in html_output
+    assert "Skeleton V2.0" in html_output
+
+    assert remove_style_tag(html_output) == """\
+<html>
+  <head>
+    <title>test report</title>
+    <meta charset="UTF-8">
+  </head>
+  <body>
+    <div class="container">
+      <h1>test report</h1>
+      <table class="u-full-width">
+        <thead>
+          <tr>
+            <th>Filename</th>
+            <th>Stmts</th>
+            <th>Miss</th>
+            <th>Cover</th>
+            <th>Missing</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Main.java</td>
+            <td>11</td>
+            <td>0</td>
+            <td>100.00%</td>
+            <td></td>
+          </tr>
+          <tr>
+            <td>search/BinarySearch.java</td>
+            <td>12</td>
+            <td>1</td>
+            <td>91.67%</td>
+            <td>24</td>
+          </tr>
+          <tr>
+            <td>search/ISortedArraySearch.java</td>
+            <td>0</td>
+            <td>0</td>
+            <td>100.00%</td>
+            <td></td>
+          </tr>
+          <tr>
+            <td>search/LinearSearch.java</td>
+            <td>7</td>
+            <td>2</td>
+            <td>71.43%</td>
+            <td>19-24</td>
+          </tr>
+        </tbody>
+        <tfoot>
+          <tr>
+            <td>TOTAL</td>
+            <td>30</td>
+            <td>3</td>
+            <td>90.00%</td>
+            <td></td>
+          </tr>
+        </tfoot>
+      </table>
+<p>Rendering of source files was disabled.</p>
     </div>
   </body>
 </html>"""


### PR DESCRIPTION
Let the HtmlReport caller
- specify a title for the report
- skip the sources detail (useful for big projects)
- replace the sources block with a message about why they are missing

The report you obtain looks like
<img width="984" alt="Capture d’écran 2020-04-19 à 15 20 06" src="https://user-images.githubusercontent.com/3499719/79688938-fefa4d80-8251-11ea-877d-681c9801417c.png">
