### PR TITLE
feat: a gitfilesystem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ var/
 *.egg-info/
 .installed.cfg
 *.egg
+.eggs
 
 # Installer logs
 pip-log.txt
@@ -55,3 +56,4 @@ docs/_build/
 
 # Editors
 *.swp
+.vscode

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 * Let the caller customize the appearance of the HTML report providing a `title`, omitting the rendering of sources by means of the boolean `render_file_sources` and providing an helpful message to the end-users (in place of the sources) by means of the `no_file_sources_message` parameter. Contributed by @nilleb.
-* Add a GitFilesystem, allowing the consumer to retrieve the sources from a git commit.
+* Add a `GitFilesystem` to allow pycobertura to access source files at different revisions from a git repository. Thanks @nilleb.
 * [BREAKING] Change the signature of the Cobertura object in order to accept a filesystem.
 
 ## 0.10.5 (2018-12-11)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,8 @@
 ## Unreleased
 
 * Let the caller customize the appearance of the HTML report providing a `title`, omitting the rendering of sources by means of the boolean `render_file_sources` and providing an helpful message to the end-users (in place of the sources) by means of the `no_file_sources_message` parameter. Contributed by @nilleb.
+* Add a GitFilesystem, allowing the consumer to retrieve the sources from a git commit.
+* [BREAKING] Change the signature of the Cobertura object in order to accept a filesystem.
 
 ## 0.10.5 (2018-12-11)
 * Use a different `memoize()` implementation so that cached objects can be freed/garbage collected and prevent from running out of memory when processing a lot of cobertura files. Thanks @kannaiah

--- a/pycobertura/cli.py
+++ b/pycobertura/cli.py
@@ -4,7 +4,7 @@ from pycobertura.cobertura import Cobertura
 from pycobertura.reporters import (
     HtmlReporter, TextReporter, HtmlReporterDelta, TextReporterDelta
 )
-
+from pycobertura.filesystem import filesystem_factory
 
 pycobertura = click.Group()
 
@@ -64,7 +64,8 @@ def get_exit_code(differ, source):
 )
 def show(cobertura_file, format, output, source, source_prefix):
     """show coverage summary of a Cobertura report"""
-    cobertura = Cobertura(cobertura_file, source=source)
+    fs = filesystem_factory(cobertura_file, source=source)
+    cobertura = Cobertura(cobertura_file, filesystem=fs)
     Reporter = reporters[format]
     reporter = Reporter(cobertura)
     report = reporter.generate()
@@ -143,16 +144,14 @@ def diff(
         color, format, output, source1, source2,
         source_prefix1, source_prefix2, source):
     """compare coverage of two Cobertura reports"""
-    cobertura1 = Cobertura(
-        cobertura_file1,
-        source=source1,
-        source_prefix=source_prefix1
+    fs1 = filesystem_factory(
+        report=cobertura_file1, source=source1, source_prefix=source_prefix1
     )
-    cobertura2 = Cobertura(
-        cobertura_file2,
-        source=source2,
-        source_prefix=source_prefix2
+    fs2 = filesystem_factory(
+        report=cobertura_file2, source=source2, source_prefix=source_prefix2
     )
+    cobertura1 = Cobertura(cobertura_file1, filesystem=fs1)
+    cobertura2 = Cobertura(cobertura_file2, filesystem=fs2)
 
     Reporter = delta_reporters[format]
     reporter_args = [cobertura1, cobertura2]

--- a/pycobertura/cobertura.py
+++ b/pycobertura/cobertura.py
@@ -431,10 +431,10 @@ class CoberturaDiff(object):
 
 
 class VersionedCobertura(Cobertura):
-    def __init__(self, report, source=None, commit_id=None):
+    def __init__(self, report, source=None, ref=None):
         super().__init__(report, source=source)
         if source is None:
             if isinstance(report, str):
                 # get the directory in which the coverage file lives
                 source = os.path.dirname(report)
-        self.filesystem = GitFileSystem(source, commit_id=commit_id)
+        self.filesystem = GitFileSystem(source, ref)

--- a/pycobertura/cobertura.py
+++ b/pycobertura/cobertura.py
@@ -47,14 +47,12 @@ class Cobertura(object):
         module in order to discover more about filesystems.
         """
         self.xml = ET.parse(report).getroot()
-        self._report = report if isinstance(report, basestring) else None
-        self._filesystem = filesystem
+        report = report if isinstance(report, basestring) else None
 
-    @property
-    def filesystem(self):
-        if not self._filesystem:
-            self._filesystem = filesystem_factory(self._report)
-        return self._filesystem
+        if filesystem:
+            self.filesystem = filesystem
+        else:
+            self.filesystem = filesystem_factory(report)
 
     @memoize
     def _get_class_element_by_filename(self, filename):

--- a/pycobertura/cobertura.py
+++ b/pycobertura/cobertura.py
@@ -1,14 +1,8 @@
 import lxml.etree as ET
-import os
-import zipfile
 
 from collections import namedtuple
 
-from pycobertura.filesystem import (
-    DirectoryFileSystem,
-    ZipFileSystem,
-    GitFileSystem
-)
+from pycobertura.filesystem import filesystem_factory
 
 
 from pycobertura.utils import (
@@ -42,37 +36,25 @@ class Cobertura(object):
     """
     An XML Cobertura parser.
     """
-    def __init__(self, report, source=None, source_prefix=None):
+    def __init__(self, report, filesystem=None):
         """
         Initialize a Cobertura report given a coverage report `report`. It can
         be either a file object or the path to an XML file that is in the
         Cobertura format.
 
-        The optional argument `source` is the location of the source code
-        provided as a directory path or a file object zip archive containing
-        the source code.
-
-        The optional argument `source_prefix` will be used to lookup source
-        files if a zip archive is provided and will be prepended to filenames
-        found in the coverage report.
+        The optional argument `filesystem` describes how to retrieve the source
+        files referenced in the report. Please check the pycobertura.filesystem
+        module in order to discover more about filesystems.
         """
         self.xml = ET.parse(report).getroot()
+        self._report = report if isinstance(report, basestring) else None
+        self._filesystem = filesystem
 
-        if source is None:
-            if isinstance(report, basestring):
-                # get the directory in which the coverage file lives
-                source = os.path.dirname(report)
-            self.filesystem = DirectoryFileSystem(
-                source, source_prefix=source_prefix
-            )
-        elif zipfile.is_zipfile(source):
-            self.filesystem = ZipFileSystem(
-                source, source_prefix=source_prefix
-            )
-        else:
-            self.filesystem = DirectoryFileSystem(
-                source, source_prefix=source_prefix
-            )
+    @property
+    def filesystem(self):
+        if not self._filesystem:
+            self._filesystem = filesystem_factory(self._report)
+        return self._filesystem
 
     @memoize
     def _get_class_element_by_filename(self, filename):
@@ -428,13 +410,3 @@ class CoberturaDiff(object):
         lines = self.file_source(filename)
         hunks = hunkify_lines(lines)
         return hunks
-
-
-class VersionedCobertura(Cobertura):
-    def __init__(self, report, source=None, ref=None):
-        super().__init__(report, source=source)
-        if source is None:
-            if isinstance(report, str):
-                # get the directory in which the coverage file lives
-                source = os.path.dirname(report)
-        self.filesystem = GitFileSystem(source, ref)

--- a/pycobertura/cobertura.py
+++ b/pycobertura/cobertura.py
@@ -7,6 +7,7 @@ from collections import namedtuple
 from pycobertura.filesystem import (
     DirectoryFileSystem,
     ZipFileSystem,
+    GitFileSystem
 )
 
 
@@ -427,3 +428,13 @@ class CoberturaDiff(object):
         lines = self.file_source(filename)
         hunks = hunkify_lines(lines)
         return hunks
+
+
+class VersionedCobertura(Cobertura):
+    def __init__(self, report, source=None, commit_id=None):
+        super().__init__(report, source=source)
+        if source is None:
+            if isinstance(report, str):
+                # get the directory in which the coverage file lives
+                source = os.path.dirname(report)
+        self.filesystem = GitFileSystem(source, commit_id=commit_id)

--- a/pycobertura/filesystem.py
+++ b/pycobertura/filesystem.py
@@ -115,7 +115,7 @@ class GitFileSystem(FileSystem):
 
         try:
             output = subprocess.check_output(shlex.split(command), cwd=self.repository)
-        except OSError:
+        except (OSError, subprocess.CalledProcessError):
             raise self.FileNotFound(filename)
 
         output = output.decode("utf-8").rstrip()

--- a/pycobertura/filesystem.py
+++ b/pycobertura/filesystem.py
@@ -144,7 +144,7 @@ def filesystem_factory(report=None, source=None, source_prefix=None, ref=None):
     """
     The optional argument `report` is the location of the cobertura report.
     It will be used to build the sources path.
- 
+
     The optional argument `source` is the location of the source code
     provided as a directory path or a file object zip archive containing
     the source code.
@@ -153,7 +153,7 @@ def filesystem_factory(report=None, source=None, source_prefix=None, ref=None):
     files if a zip archive is provided and will be prepended to filenames
     found in the coverage report.
 
-    The oprional argument `ref` will be taken into account when
+    The optional argument `ref` will be taken into account when
     instantiating a GitFileSystem, and it shall be a branch name, a commit
     ID or a git ref ID.
     """
@@ -167,10 +167,7 @@ def filesystem_factory(report=None, source=None, source_prefix=None, ref=None):
             source, source_prefix=source_prefix
         )
 
-    if os.path.isfile(source):
-        source = os.path.dirname(source)
-
     if ref:
         return GitFileSystem(source, ref)
-    else:
-        return DirectoryFileSystem(source, source_prefix=source_prefix)
+
+    return DirectoryFileSystem(source, source_prefix=source_prefix)

--- a/pycobertura/filesystem.py
+++ b/pycobertura/filesystem.py
@@ -138,3 +138,39 @@ class GitFileSystem(FileSystem):
 
         output = output.decode("utf-8").rstrip()
         yield io.StringIO(output)
+
+
+def filesystem_factory(report=None, source=None, source_prefix=None, ref=None):
+    """
+    The optional argument `report` is the location of the cobertura report.
+    It will be used to build the sources path.
+ 
+    The optional argument `source` is the location of the source code
+    provided as a directory path or a file object zip archive containing
+    the source code.
+
+    The optional argument `source_prefix` will be used to lookup source
+    files if a zip archive is provided and will be prepended to filenames
+    found in the coverage report.
+
+    The oprional argument `ref` will be taken into account when
+    instantiating a GitFileSystem, and it shall be a branch name, a commit
+    ID or a git ref ID.
+    """
+    if source is None:
+        if isinstance(report, str):
+            # get the directory in which the coverage file lives
+            source = os.path.dirname(report)
+
+    if zipfile.is_zipfile(source):
+        return ZipFileSystem(
+            source, source_prefix=source_prefix
+        )
+
+    if os.path.isfile(source):
+        source = os.path.dirname(source)
+
+    if ref:
+        return GitFileSystem(source, ref)
+    else:
+        return DirectoryFileSystem(source, source_prefix=source_prefix)

--- a/pycobertura/filesystem.py
+++ b/pycobertura/filesystem.py
@@ -92,9 +92,8 @@ class GitFileSystem(FileSystem):
 
     def has_file(self, filename):
         command = "git --no-pager show {}".format(self.real_filename(filename))
-        command_tokens = shlex.split(command)
         return_code = subprocess.call(
-            command_tokens,
+            command,
             cwd=self.repository,
             shell=True,
             stdout=subprocess.DEVNULL,

--- a/pycobertura/utils.py
+++ b/pycobertura/utils.py
@@ -1,6 +1,8 @@
 import colorama
 import difflib
 from functools import partial
+import logging
+import subprocess
 
 
 # Recipe from https://github.com/ActiveState/
@@ -208,3 +210,15 @@ def hunkify_lines(lines, context=3):
         hunks.append(hunk)
 
     return hunks
+
+
+def get_output(command, working_folder=None):
+    logging.debug("Executing %s in %s", command, working_folder)
+
+    try:
+        output = subprocess.check_output(shlex.split(command), cwd=working_folder)
+        return output.decode("utf-8")
+    except OSError:
+        logging.error("Command being executed: {}".format(command))
+        raise
+

--- a/pycobertura/utils.py
+++ b/pycobertura/utils.py
@@ -1,8 +1,6 @@
 import colorama
 import difflib
 from functools import partial
-import logging
-import subprocess
 
 
 # Recipe from https://github.com/ActiveState/
@@ -210,15 +208,3 @@ def hunkify_lines(lines, context=3):
         hunks.append(hunk)
 
     return hunks
-
-
-def get_output(command, working_folder=None):
-    logging.debug("Executing %s in %s", command, working_folder)
-
-    try:
-        output = subprocess.check_output(shlex.split(command), cwd=working_folder)
-        return output.decode("utf-8")
-    except OSError:
-        logging.error("Command being executed: {}".format(command))
-        raise
-

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,6 @@
 [tool:pytest]
 norecursedirs = build docs/_build *.egg .tox *.venv tests/dummy*
+junit_family=xunit1
 addopts =
     # Shows a line for every test
     # You probably want to turn this off if you use pytest-sugar.

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,3 @@
-coverage>=4.0,<4.4
+coverage
 mock
-pytest-cov<2.6.0
+pytest-cov

--- a/tests/test_cobertura.py
+++ b/tests/test_cobertura.py
@@ -182,7 +182,7 @@ def test_total_hits_by_class_file():
 
 def test_class_file_source__sources_not_found():
     from pycobertura.cobertura import Line
-    cobertura = make_cobertura('tests/cobertura.xml')
+    cobertura = make_cobertura()
     expected_sources = {
         'Main.java': [Line(0, 'tests/Main.java not found', None, None)],
         'search/BinarySearch.java': [Line(0, 'tests/search/BinarySearch.java not found', None, None)],

--- a/tests/test_cobertura.py
+++ b/tests/test_cobertura.py
@@ -9,9 +9,8 @@ def test_parse_path():
 
     xml_path = 'foo.xml'
 
-    with mock.patch('pycobertura.cobertura.os.path.exists', return_value=True):
-        with mock.patch('pycobertura.cobertura.ET.parse') as mock_parse:
-            cobertura = Cobertura(xml_path)
+    with mock.patch('pycobertura.cobertura.ET.parse') as mock_parse:
+        cobertura = Cobertura(xml_path)
 
     assert cobertura.xml is mock_parse.return_value.getroot.return_value
 

--- a/tests/test_filesystem.py
+++ b/tests/test_filesystem.py
@@ -1,6 +1,9 @@
 from unittest.mock import patch, MagicMock
 
 
+FIRST_PYCOBERTURA_COMMIT_SHA = "d1fe88da6b18340762b24bb1f89067a3439c4041"
+
+
 def test_filesystem_directory__file_not_found():
     from pycobertura.filesystem import DirectoryFileSystem
 
@@ -108,12 +111,14 @@ def test_filesystem_git():
         subprocess_mock.check_output = MagicMock(return_value=b"<file-content>")
 
         fs = GitFileSystem(folder, branch)
-        git_filename = fs.real_filename(filename)
 
         with fs.open(filename) as f:
             assert hasattr(f, 'read')
 
-        assert git_filename.startswith(branch)
+        expected_git_filename = "master:tests/dummy/test-file"
+        git_filename = fs.real_filename(filename)
+        assert git_filename == expected_git_filename 
+
         expected_command = ["git", "--no-pager", "show", git_filename]
         subprocess_mock.check_output.assert_called_with(expected_command, cwd=folder)
 
@@ -121,8 +126,9 @@ def test_filesystem_git():
 def test_filesystem_git_integration():
     from pycobertura.filesystem import GitFileSystem
 
-    fs = GitFileSystem(".", "d1fe88da6b18340762b24bb1f89067a3439c4041")
+    fs = GitFileSystem(".", FIRST_PYCOBERTURA_COMMIT_SHA)
 
+    # Files included in pycobertura's first commit.
     source_files = [
         'README.md',
         '.gitignore',
@@ -136,7 +142,7 @@ def test_filesystem_git_integration():
 def test_filesystem_git_integration__not_found():
     from pycobertura.filesystem import GitFileSystem
 
-    fs = GitFileSystem(".", "d1fe88da6b18340762b24bb1f89067a3439c4041")
+    fs = GitFileSystem(".", FIRST_PYCOBERTURA_COMMIT_SHA)
 
     dummy_source_file = "CHANGES.md"
 

--- a/tests/test_filesystem.py
+++ b/tests/test_filesystem.py
@@ -103,14 +103,13 @@ def test_filesystem_zip__with_source_prefix():
 
 def test_filesystem_git():
     import pycobertura.filesystem as fsm
-    from pycobertura.filesystem import GitFileSystem
 
     branch, folder, filename = "master", "tests/dummy", "test-file"
 
     with patch.object(fsm, "subprocess") as subprocess_mock:
         subprocess_mock.check_output = MagicMock(return_value=b"<file-content>")
 
-        fs = GitFileSystem(folder, branch)
+        fs = fsm.GitFileSystem(folder, branch)
 
         with fs.open(filename) as f:
             assert hasattr(f, 'read')

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -4,6 +4,6 @@ SOURCE_FILE = 'tests/cobertura.xml'
 def make_cobertura(xml=SOURCE_FILE, **kwargs):
     from pycobertura import Cobertura
     from pycobertura.filesystem import filesystem_factory
-    filesystem_factory(xml, **kwargs)
-    cobertura = Cobertura(xml)
+    source_filesystem = filesystem_factory(xml, **kwargs)
+    cobertura = Cobertura(xml, filesystem=source_filesystem)
     return cobertura

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,7 +1,9 @@
 SOURCE_FILE = 'tests/cobertura.xml'
 
 
-def make_cobertura(xml=SOURCE_FILE, *args, **kwargs):
+def make_cobertura(xml=SOURCE_FILE, **kwargs):
     from pycobertura import Cobertura
-    cobertura = Cobertura(xml, *args, **kwargs)
+    from pycobertura.filesystem import filesystem_factory
+    filesystem_factory(xml, **kwargs)
+    cobertura = Cobertura(xml)
     return cobertura

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 skipsdist = True
-envlist = py34, py37, py38, pep8
+envlist = py35, py36, py37, py38, pep8
 
 [testenv]
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 skipsdist = True
-envlist = py26, py27, py34, pep8
+envlist = py34, py37, py38, pep8
 
 [testenv]
 commands =


### PR DESCRIPTION
The consumer of the VersionedCobertura has the possibility to inspect a coverage report from the past along with the corresponding sources.

Usage:
```python
VersionedCobertura(report, source=source, commit_id=commit_id)
```
Where `report` is the Cobertura report, `source` is the folder where the Git repository can be found and `commit` is the commit ID to which the report is associated.