### PR TITLE
Fix support to init `Cobertura` with a file object

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,17 @@
 language: python
-python:
-  - "3.5"
-  - "3.6"      # current default Python on Travis CI
-  - "3.7"
+jobs:
+  include:
+    - python: 3.5
+      env: TOXENV=py35
+    - python: 3.6
+      env: TOXENV=py36
+    - python: 3.7
+      env: TOXENV=py37
+    - env: TOXENV=pep8
+    - env: TOXENV=black
 
 install:
-    - pip install tox-travis
+  - pip install tox
 
 # Because the tests access the first git commit, we need to fetch the whole
 # pycobertura repository without using a git --depth parameter. See
@@ -14,7 +20,7 @@ git:
   depth: false
 
 script:
-    - tox
+  - tox
 
 after_success:
   - |

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * Support loading Cobertura reports from an XML string. Thanks @williamfzc
+* Fix (or add?!) support for providing file objects to `Cobertura`.
 
 ## 1.0.1 (2020-07-08)
 

--- a/pycobertura/filesystem.py
+++ b/pycobertura/filesystem.py
@@ -151,7 +151,9 @@ def filesystem_factory(report=None, source=None, source_prefix=None, ref=None):
     ID or a git ref ID.
     """
     if source is None:
-        if isinstance(report, str):
+        if isinstance(report, io.IOBase):
+            source = os.path.dirname(report.name)
+        elif isinstance(report, str):
             # get the directory in which the coverage file lives
             source = os.path.dirname(report)
 

--- a/tests/test_cobertura.py
+++ b/tests/test_cobertura.py
@@ -9,9 +9,18 @@ def test_parse_path():
     from pycobertura import Cobertura
 
     xml_path = 'tests/cobertura.xml'
-
     with mock.patch('pycobertura.cobertura.ET.parse') as mock_parse:
         cobertura = Cobertura(xml_path)
+
+    assert cobertura.xml is mock_parse.return_value.getroot.return_value
+
+
+def test_parse_file_object():
+    from pycobertura import Cobertura
+
+    xml_path = 'tests/cobertura.xml'
+    with mock.patch('pycobertura.cobertura.ET.parse') as mock_parse:
+        cobertura = Cobertura(open(xml_path))
 
     assert cobertura.xml is mock_parse.return_value.getroot.return_value
 
@@ -23,6 +32,13 @@ def test_parse_string():
     with open(xml_path) as f:
         xml_string = f.read()
     assert ET.tostring(Cobertura(xml_path).xml) == ET.tostring(Cobertura(xml_string).xml)
+
+
+def test_invalid_coverage_report():
+    from pycobertura import Cobertura
+
+    xml_path = 'non-existent.xml'
+    pytest.raises(Cobertura.InvalidCoverageReport, Cobertura, xml_path)
 
 
 def test_version():


### PR DESCRIPTION
It's unclear if we had support for file objects in the first place. It was documented but unsure if it ever worked. ¯\\_(ツ)_/¯