### PR TITLE
Don't create a `FileSystem` upon init of `Cobertura`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,17 @@
 
 ## Unreleased
 
+* BACKWARD INCOMPATIBLE: The class `Cobertura` no longer instantiates a default
+  `FileSystem` object if none is provided in the constructor
+  `Cobertura.__init__(filesystem=...)`. If the content of files is accessed
+  (e.g. to render a full coverage report) then a `FileSystem` instance must be
+  provided.
+* The class `Cobertura` will raise `FileSystemMissingForSource` if no
+  `FileSystem` object was provided via the keyword argument
+  `Cobertura(filesystem=...)`. It will only be raised when calling methods that
+  attempt to read the content of files, e.g. `Cobertura.file_source(...)` or
+  `Cobertura.source_lines(...)`.
+
 ## 1.1.0 (2020-08-26)
 
 * Support loading Cobertura reports from an XML string. Thanks @williamfzc

--- a/pycobertura/filesystem.py
+++ b/pycobertura/filesystem.py
@@ -133,30 +133,17 @@ class GitFileSystem(FileSystem):
         yield io.StringIO(output)
 
 
-def filesystem_factory(report=None, source=None, source_prefix=None, ref=None):
+def filesystem_factory(source, source_prefix=None, ref=None):
     """
-    The optional argument `report` is the location of the cobertura report.
-    It will be used to build the sources path.
+    The argument `source` is the location of the source code provided as a
+    directory path or a file object zip archive containing the source code.
 
-    The optional argument `source` is the location of the source code
-    provided as a directory path or a file object zip archive containing
-    the source code.
+    The optional argument `source` is the location of the source code provided
+    as a directory path or a file object zip archive containing the source code.
 
-    The optional argument `source_prefix` will be used to lookup source
-    files if a zip archive is provided and will be prepended to filenames
-    found in the coverage report.
-
-    The optional argument `ref` will be taken into account when
-    instantiating a GitFileSystem, and it shall be a branch name, a commit
-    ID or a git ref ID.
+    The optional argument `ref` will be taken into account when instantiating a
+    GitFileSystem, and it shall be a branch name, a commit ID or a git ref ID.
     """
-    if source is None:
-        if isinstance(report, io.IOBase):
-            source = os.path.dirname(report.name)
-        elif isinstance(report, str):
-            # get the directory in which the coverage file lives
-            source = os.path.dirname(report)
-
     if zipfile.is_zipfile(source):
         return ZipFileSystem(source, source_prefix=source_prefix)
 

--- a/pycobertura/utils.py
+++ b/pycobertura/utils.py
@@ -1,5 +1,7 @@
 import colorama
 import difflib
+import os
+
 from functools import partial
 
 
@@ -208,3 +210,7 @@ def hunkify_lines(lines, context=3):
         hunks.append(hunk)
 
     return hunks
+
+
+def get_dir_from_file_path(file_path):
+    return os.path.dirname(file_path) or "."

--- a/tests/test_cobertura.py
+++ b/tests/test_cobertura.py
@@ -279,3 +279,24 @@ def test_class_file_source__sources_found(report, source, source_prefix):
     for filename in cobertura.files():
         assert cobertura.file_source(filename) == \
                expected_sources[filename]
+
+
+def test_class_file_source__raises_when_no_filesystem():
+    from pycobertura.cobertura import Cobertura
+    cobertura = Cobertura('tests/cobertura.xml')
+    for filename in cobertura.files():
+        pytest.raises(
+            Cobertura.FileSystemMissingForSource,
+            cobertura.file_source,
+            filename
+        )
+
+def test_class_source_lines__raises_when_no_filesystem():
+    from pycobertura.cobertura import Cobertura
+    cobertura = Cobertura('tests/cobertura.xml')
+    for filename in cobertura.files():
+        pytest.raises(
+            Cobertura.FileSystemMissingForSource,
+            cobertura.source_lines,
+            filename
+        )

--- a/tests/test_cobertura_diff.py
+++ b/tests/test_cobertura_diff.py
@@ -137,8 +137,9 @@ def test_diff_total_hits_by_class_file():
 def test_diff__has_all_changes_covered__some_changed_code_is_still_uncovered():
     from pycobertura.cobertura import Cobertura, CoberturaDiff
 
-    cobertura1 = Cobertura('tests/dummy.zeroexit1/coverage.xml')
-    cobertura2 = Cobertura('tests/dummy.zeroexit2/coverage.xml')
+    cobertura1 = make_cobertura('tests/dummy.zeroexit1/coverage.xml')
+    cobertura2 = make_cobertura('tests/dummy.zeroexit2/coverage.xml')
+
     differ = CoberturaDiff(cobertura1, cobertura2)
     assert differ.has_all_changes_covered() is False
 

--- a/tests/test_filesystem.py
+++ b/tests/test_filesystem.py
@@ -117,7 +117,7 @@ def test_filesystem_git():
 
         expected_git_filename = "master:tests/dummy/test-file"
         git_filename = fs.real_filename(filename)
-        assert git_filename == expected_git_filename 
+        assert git_filename == expected_git_filename
 
         expected_command = ["git", "--no-pager", "show", git_filename]
         subprocess_mock.check_output.assert_called_with(expected_command, cwd=folder)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,9 +1,11 @@
-SOURCE_FILE = 'tests/cobertura.xml'
+from pycobertura import Cobertura
+from pycobertura.filesystem import filesystem_factory
+from pycobertura.utils import get_dir_from_file_path
 
 
-def make_cobertura(xml=SOURCE_FILE, **kwargs):
-    from pycobertura import Cobertura
-    from pycobertura.filesystem import filesystem_factory
-    source_filesystem = filesystem_factory(xml, **kwargs)
+def make_cobertura(xml='tests/cobertura.xml', source=None, **kwargs):
+    if not source:
+        source = get_dir_from_file_path(xml)
+    source_filesystem = filesystem_factory(source, **kwargs)
     cobertura = Cobertura(xml, filesystem=source_filesystem)
     return cobertura


### PR DESCRIPTION
It's too tricky to detect what type of filesystem we want to use based on the
input. Instead, we let the caller decide and provide us with their desired
filesystem explicitly.

This change is backward incompatible.