### PR TITLE
Rename `FileSystemMissingForSource` -> `MissingFileSystem`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,7 +7,7 @@
   `Cobertura.__init__(filesystem=...)`. If the content of files is accessed
   (e.g. to render a full coverage report) then a `FileSystem` instance must be
   provided.
-* The class `Cobertura` will raise `FileSystemMissingForSource` if no
+* The class `Cobertura` will raise `MissingFileSystem` if no
   `FileSystem` object was provided via the keyword argument
   `Cobertura(filesystem=...)`. It will only be raised when calling methods that
   attempt to read the content of files, e.g. `Cobertura.file_source(...)` or

--- a/pycobertura/cobertura.py
+++ b/pycobertura/cobertura.py
@@ -37,7 +37,7 @@ class Cobertura(object):
     class InvalidCoverageReport(Exception):
         pass
 
-    class FileSystemMissingForSource(Exception):
+    class MissingFileSystem(Exception):
         pass
 
     def __init__(self, report, filesystem=None):
@@ -162,8 +162,8 @@ class Cobertura(object):
         statuses = extrapolate_coverage(statuses)
         return [lno for lno, status in statuses if status is False]
 
-    def _raise_FileSystemMissingForSource(self, filename):
-        raise self.FileSystemMissingForSource(
+    def _raise_MissingFileSystem(self, filename):
+        raise self.MissingFileSystem(
             "Unable to read file: {filename}. "
             "A FileSystem instance must be provided via "
             "Cobertura(filesystem=...) to locate and read the source "
@@ -177,7 +177,7 @@ class Cobertura(object):
         source file with the given `filename`.
         """
         if self.filesystem is None:
-            self._raise_FileSystemMissingForSource(filename)
+            self._raise_MissingFileSystem(filename)
 
         lines = []
         try:
@@ -272,7 +272,7 @@ class Cobertura(object):
         Return a list for source lines of file `filename`.
         """
         if self.filesystem is None:
-            self._raise_FileSystemMissingForSource(filename)
+            self._raise_MissingFileSystem(filename)
 
         with self.filesystem.open(filename) as f:
             return f.readlines()

--- a/tests/test_cobertura.py
+++ b/tests/test_cobertura.py
@@ -286,7 +286,7 @@ def test_class_file_source__raises_when_no_filesystem():
     cobertura = Cobertura('tests/cobertura.xml')
     for filename in cobertura.files():
         pytest.raises(
-            Cobertura.FileSystemMissingForSource,
+            Cobertura.MissingFileSystem,
             cobertura.file_source,
             filename
         )
@@ -296,7 +296,7 @@ def test_class_source_lines__raises_when_no_filesystem():
     cobertura = Cobertura('tests/cobertura.xml')
     for filename in cobertura.files():
         pytest.raises(
-            Cobertura.FileSystemMissingForSource,
+            Cobertura.MissingFileSystem,
             cobertura.source_lines,
             filename
         )


### PR DESCRIPTION
It rolls off the tongue better.