### PR TITLE
Feature/per directory coverage

### DIFF
--- a/pycobertura/cli.py
+++ b/pycobertura/cli.py
@@ -48,7 +48,7 @@ def get_exit_code(differ, source):
 
 @pycobertura.command()
 @click.argument("cobertura_file")
-@click.option("-f", "--format", default="textdir", type=click.Choice(list(reporters)))
+@click.option("-f", "--format", default="text", type=click.Choice(list(reporters)))
 @click.option(
     "-o",
     "--output",

--- a/pycobertura/cli.py
+++ b/pycobertura/cli.py
@@ -4,6 +4,7 @@ from pycobertura.cobertura import Cobertura
 from pycobertura.reporters import (
     HtmlReporter,
     TextReporter,
+    TextDirectorySummaryReporter,
     HtmlReporterDelta,
     TextReporterDelta,
 )
@@ -16,6 +17,7 @@ pycobertura = click.Group()
 reporters = {
     "html": HtmlReporter,
     "text": TextReporter,
+    "textdir": TextDirectorySummaryReporter
 }
 
 
@@ -46,7 +48,7 @@ def get_exit_code(differ, source):
 
 @pycobertura.command()
 @click.argument("cobertura_file")
-@click.option("-f", "--format", default="text", type=click.Choice(list(reporters)))
+@click.option("-f", "--format", default="textdir", type=click.Choice(list(reporters)))
 @click.option(
     "-o",
     "--output",
@@ -180,6 +182,8 @@ def diff(
     source,
 ):
     """compare coverage of two Cobertura reports"""
+    print("diffsnaotehusanotehusaontehu")
+
     # Assume that the source is located in the same directory as the provided
     # coverage files if no source directories are provided.
     if not source1:

--- a/pycobertura/cli.py
+++ b/pycobertura/cli.py
@@ -182,8 +182,6 @@ def diff(
     source,
 ):
     """compare coverage of two Cobertura reports"""
-    print("diffsnaotehusanotehusaontehu")
-
     # Assume that the source is located in the same directory as the provided
     # coverage files if no source directories are provided.
     if not source1:

--- a/pycobertura/reporters.py
+++ b/pycobertura/reporters.py
@@ -71,6 +71,8 @@ class TextReporter(Reporter):
         return row
 
     def generate(self):
+        lines = self.get_report_lines()
+
         formatted_lines = []
         for row in lines:
             formatted_row = self.format_row(row)

--- a/pycobertura/reporters.py
+++ b/pycobertura/reporters.py
@@ -4,7 +4,8 @@ from pycobertura.cobertura import CoberturaDiff
 from pycobertura.utils import green, rangify, red
 from pycobertura.templates import filters
 from tabulate import tabulate
-
+from pathlib import Path
+import yaml
 
 env = Environment(loader=PackageLoader("pycobertura", "templates"))
 env.filters["line_status"] = filters.line_status
@@ -70,8 +71,6 @@ class TextReporter(Reporter):
         return row
 
     def generate(self):
-        lines = self.get_report_lines()
-
         formatted_lines = []
         for row in lines:
             formatted_row = self.format_row(row)
@@ -83,6 +82,82 @@ class TextReporter(Reporter):
 
         return report
 
+class TextDirectorySummaryReporter(Reporter):
+    def format_row(self, last_path, dir_total_lines, dir_total_missed):
+        formatted_missed_lines = ""
+        percent = 0
+        if (dir_total_lines != 0 and dir_total_missed != 0):
+            percent = (dir_total_lines - dir_total_missed) / dir_total_lines * 100
+
+        row = file_row_missed(
+            last_path,
+            dir_total_lines,
+            dir_total_missed,
+            percent,
+            formatted_missed_lines,
+        )
+
+        return row
+
+    def generate(self):
+        fileset = {}
+        reverseset = {}
+        resultgroup = {}
+        lines = self.get_report_lines()
+        with open("/home/willi/src/pycobertura/pycobertura/groups.yml") as fileh:
+            fileset = yaml.load(fileh, Loader=yaml.Loader)
+        for key in fileset.keys():
+            for directory in fileset[key].split(' '):
+                reverseset[directory] = key
+        dir_total_lines = 0
+        dir_total_missed = 0
+
+        lines = self.get_report_lines()
+        last_path = Path()
+        formatted_lines = []
+        for row in lines:
+            filename, total_lines, total_misses, line_rate, missed_lines = row
+            path = Path(filename).parents[0]
+            if last_path == Path():
+                last_path = path
+                dir_total_lines = total_lines
+                dir_total_missed = total_misses
+            elif last_path != path:
+                formatted_row = self.format_row(last_path, dir_total_lines, dir_total_missed)
+                formatted_lines.append(formatted_row)
+                strpath = str(last_path)
+                if strpath in reverseset:
+                    k = reverseset[strpath]
+                    if k in resultgroup:
+                        resultgroup[k]['dir_total_lines'] += dir_total_lines
+                        resultgroup[k]['dir_total_missed'] += dir_total_missed
+                    else:                        
+                        resultgroup[k] = {
+                            'dir_total_lines': dir_total_lines,
+                            'dir_total_missed': dir_total_missed
+                            }
+                else:
+                    print('path not covered in config: ' + strpath)
+                last_path = path
+                dir_total_lines = 0
+                dir_total_missed = 0
+            else:
+                dir_total_lines += total_lines
+                dir_total_missed += total_misses
+
+        report = tabulate(
+            formatted_lines, headers=["Directories", "Stmts", "Miss", "Cover", "Missing"]
+        )
+
+        for key in fileset.keys():
+            res = resultgroup[key]
+            percent = 0
+            if (res['dir_total_lines'] != 0 and res['dir_total_missed'] != 0):
+                percent = (res['dir_total_lines'] - res['dir_total_missed']) / res['dir_total_lines'] * 100
+
+            print(key + " - %+.2f%%" %(percent) + " %")
+
+        return report
 
 class HtmlReporter(TextReporter):
     def __init__(self, *args, **kwargs):

--- a/pycobertura/reporters.py
+++ b/pycobertura/reporters.py
@@ -104,7 +104,7 @@ class TextDirectorySummaryReporter(Reporter):
         reverseset = {}
         resultgroup = {}
         lines = self.get_report_lines()
-        with open("/home/willi/src/pycobertura/pycobertura/groups.yml") as fileh:
+        with open("pycobertura/groups.yml") as fileh:
             fileset = yaml.load(fileh, Loader=yaml.Loader)
         for key in fileset.keys():
             for directory in fileset[key].split(' '):


### PR DESCRIPTION
as discussed in https://github.com/aconrad/pycobertura/issues/108 I need another formatter that groups sources by directory and other criteria. 

I would make this a draft pr since this is still very hacky, but for some reason github won't let me. 

the yml for grouping looks like this:
```
Cache:
  coverage/arangod/Cache
Cluster:
  coverage/arangod/Cluster
  coverage/arangod/Network
  coverage/arangod/Sharding
```