### PR TITLE
Drop colorama dependency in favor of static ANSI escape codes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## Unreleased
+
+* Drop the `colorama` dependency in favor of hardcoded ANSI escape codes
+
 ## 2.0.0 (2020-09-03)
 
 * BACKWARD INCOMPATIBLE: The class `Cobertura` no longer instantiates a default

--- a/pycobertura/utils.py
+++ b/pycobertura/utils.py
@@ -1,8 +1,13 @@
-import colorama
 import difflib
 import os
 
 from functools import partial
+
+ANSI_ESCAPE_CODES = {
+    "green": "\x1b[32m",
+    "red": "\x1b[31m",
+    "reset": "\x1b[39m",
+}
 
 
 # Recipe from https://github.com/ActiveState/
@@ -48,8 +53,8 @@ class memoize(object):
 
 
 def colorize(text, color):
-    color_code = getattr(colorama.Fore, color.upper())
-    return "%s%s%s" % (color_code, text, colorama.Fore.RESET)
+    color_code = ANSI_ESCAPE_CODES[color]
+    return "%s%s%s" % (color_code, text, ANSI_ESCAPE_CODES["reset"])
 
 
 def red(text):

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     packages=find_packages(exclude=['tests']),
     long_description='%s\n\n%s' % (README, CHANGES),
     setup_requires=['setuptools_git'],
-    install_requires=['click>=4.0', 'colorama', 'jinja2', 'lxml', 'tabulate'],
+    install_requires=['click>=4.0', 'jinja2', 'lxml', 'tabulate'],
     classifiers=[
         "Topic :: Software Development :: Libraries :: Python Modules",
         "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
Currently, `pycobertura` uses `colorama` exclusively to get the ANSI escape codes for red, green, and reset: https://github.com/aconrad/pycobertura/blob/fdbbc8aea2a5d977979bd2f57d0f0e4b81c7b715/pycobertura/utils.py#L50-L60

However, `colorama` is meant for making ANSI color codes work on Windows ([README](https://github.com/tartley/colorama#colorama)), and installing it on other platforms can lead to unexpected issues. This PR drops the `colorama` dependency in favor of hardcoded ANSI escape codes.

### Background

We've been seeing exceptions in our supervisor logging due to `colorama` being unexpectedly initialized:
```
Traceback (most recent call last):
  File "/home/app/.pex/unzipped_pexes/84659276c62b0e288dba64c1e1f55d821376d3c3/.deps/supervisor-4.2.0-py2.py3-none-any.whl/supervisor/loggers.py", line 102, in emit
    self.stream.write(msg)
  File "/home/app/.pex/unzipped_pexes/84659276c62b0e288dba64c1e1f55d821376d3c3/.deps/colorama-0.4.3-py2.py3-none-any.whl/colorama/ansitowin32.py", line 41, in write
    self.__convertor.write(text)
  File "/home/app/.pex/unzipped_pexes/84659276c62b0e288dba64c1e1f55d821376d3c3/.deps/colorama-0.4.3-py2.py3-none-any.whl/colorama/ansitowin32.py", line 162, in write
    self.write_and_convert(text)
  File "/home/app/.pex/unzipped_pexes/84659276c62b0e288dba64c1e1f55d821376d3c3/.deps/colorama-0.4.3-py2.py3-none-any.whl/colorama/ansitowin32.py", line 184, in write_and_convert
    text = self.convert_osc(text)
  File "/home/app/.pex/unzipped_pexes/84659276c62b0e288dba64c1e1f55d821376d3c3/.deps/colorama-0.4.3-py2.py3-none-any.whl/colorama/ansitowin32.py", line 246, in convert_osc
    for match in self.ANSI_OSC_RE.finditer(text):
TypeError: cannot use a string pattern on a bytes-like object
```

We tracked this down to the `colorama` init call inside of `colorlog`. In addition to `colorlog`, our application also depends on another library (`pycobertura`) which depends on `colorama`. As a result, `colorama` is importable and is initialized by `colorlog`, despite running on a non-Windows platform.
