### PR TITLE
Add option to hide missing column in HtmlReporterDelta

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+* Added the option `show_missing` to `HtmlReporterDelta`, which specifies
+  whether or not the "Missing" column is displayed in the generated
+  summary table.
+
 ## 2.0.1 (2021-01-20)
 
 * Drop the `colorama` dependency in favor of hardcoded ANSI escape codes.

--- a/pycobertura/reporters.py
+++ b/pycobertura/reporters.py
@@ -239,6 +239,16 @@ class TextReporterDelta(DeltaReporter):
 
 
 class HtmlReporterDelta(TextReporterDelta):
+    def __init__(self, *args, **kwargs):
+        """
+        Takes the same arguments as `TextReporterDelta` but also takes the keyword
+        argument `show_missing` which can be set to True or False to set whether
+        or not the generated report should contain a listing of missing lines in
+        the summary table.
+        """
+        self.show_missing = kwargs.pop("show_missing", True)
+        super(HtmlReporterDelta, self).__init__(*args, **kwargs)
+
     def get_source_hunks(self, filename):
         hunks = self.differ.file_source_hunks(filename)
         return hunks
@@ -248,7 +258,7 @@ class HtmlReporterDelta(TextReporterDelta):
         total_misses = "%+d" % row.total_misses if row.total_misses else "-"
         line_rate = "%+.2f%%" % (row.line_rate * 100) if row.line_rate else "-"
 
-        if self.show_source is True:
+        if self.show_source is True and self.show_missing is True:
             missed_lines = [
                 "%s%d" % (["-", "+"][is_new], lno) for lno, is_new in row.missed_lines
             ]
@@ -260,7 +270,7 @@ class HtmlReporterDelta(TextReporterDelta):
             line_rate,
         ]
 
-        if self.show_source is True:
+        if self.show_source is True and self.show_missing is True:
             row_values.append(missed_lines)
             row = file_row_missed(*row_values)
         else:
@@ -289,6 +299,7 @@ class HtmlReporterDelta(TextReporterDelta):
         render_kwargs = {
             "lines": formatted_lines[:-1],
             "footer": formatted_lines[-1],
+            "show_missing": self.show_missing,
             "show_source": self.show_source,
         }
 

--- a/pycobertura/templates/html-delta.jinja2
+++ b/pycobertura/templates/html-delta.jinja2
@@ -28,7 +28,7 @@ table.code td.lineno pre {margin-right: 1rem;}
             <th>Stmts</th>
             <th>Miss</th>
             <th>Cover</th>
-{%- if show_source %}
+{%- if show_source and show_missing %}
             <th>Missing</th>
 {%- endif %}
           </tr>
@@ -40,7 +40,7 @@ table.code td.lineno pre {margin-right: 1rem;}
             <td>{{ line.total_statements }}</td>
             <td><span{% if line.total_misses != '-' %} class="{% if line.total_misses[0] == '+' %}red{% else %}green{% endif%}"{% endif %}>{{ line.total_misses }}</span></td>
             <td>{{ line.line_rate }}</td>
-{%- if show_source %}
+{%- if show_source and show_missing %}
             <td>
 {%- for missed_line in line.missed_lines %}
             {%- if not loop.first %}, {% endif %}<span class="{% if missed_line[0] == '+' %}red{% else %}green{% endif %}">{{ missed_line }}</span>
@@ -56,7 +56,7 @@ table.code td.lineno pre {margin-right: 1rem;}
             <td>{{ footer.total_statements }}</td>
             <td><span{% if footer.total_misses != '-' %} class="{% if footer.total_misses[0] == '+' %}red{% else %}green{% endif%}"{% endif %}>{{ footer.total_misses }}</span></td>
             <td>{{ footer.line_rate }}</td>
-{%- if show_source %}
+{%- if show_source and show_missing %}
             <td></td>
 {%- endif %}
           </tr>

--- a/tests/test_reporters.py
+++ b/tests/test_reporters.py
@@ -531,3 +531,133 @@ def test_html_report_delta():
     </div>
   </body>
 </html>"""
+
+
+def test_html_report_delta__show_missing_False():
+    from pycobertura.reporters import HtmlReporterDelta
+
+    cobertura1 = make_cobertura('tests/dummy.source1/coverage.xml')
+    cobertura2 = make_cobertura('tests/dummy.source2/coverage.xml')
+
+    report_delta = HtmlReporterDelta(cobertura1, cobertura2, show_missing=False)
+    html_output = report_delta.generate()
+
+    assert remove_style_tag(html_output) == u"""\
+<html>
+  <head>
+    <title>pycobertura report</title>
+    <meta charset="UTF-8">
+  </head>
+  <body>
+    <div class="container">
+      <table class="u-full-width">
+        <thead>
+          <tr>
+            <th>Filename</th>
+            <th>Stmts</th>
+            <th>Miss</th>
+            <th>Cover</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><a href="#dummy/dummy.py">dummy/dummy.py</a></td>
+            <td>-</td>
+            <td><span class="green">-2</span></td>
+            <td>+40.00%</td>
+          </tr>
+          <tr>
+            <td><a href="#dummy/dummy2.py">dummy/dummy2.py</a></td>
+            <td>+2</td>
+            <td><span class="red">+1</span></td>
+            <td>-25.00%</td>
+          </tr>
+          <tr>
+            <td><a href="#dummy/dummy3.py">dummy/dummy3.py</a></td>
+            <td>+2</td>
+            <td><span class="red">+2</span></td>
+            <td>-</td>
+          </tr>
+        </tbody>
+        <tfoot>
+          <tr>
+            <td>TOTAL</td>
+            <td>+4</td>
+            <td><span class="red">+1</span></td>
+            <td>+31.06%</td>
+          </tr>
+        </tfoot>
+      </table><div class="legend">
+  <dl>
+    <dt><code>code</code></dt><dd>coverage unchanged</dd>
+    <dt class="hit"><code>code</code></dt><dd>coverage increased</dd>
+    <dt class="miss"><code>code</code></dt><dd>coverage decreased</dd>
+    <dt><code>+</code></dt><dd>line added or modified</dd>
+  </dl>
+</div>
+<h4 id="dummy/dummy.py">dummy/dummy.py</h4>
+<table class="code u-max-full-width">
+  <tbody>
+    <tr>
+      <td class="lineno">
+        <pre>2 &nbsp;
+3 &nbsp;
+4 &nbsp;
+5 &nbsp;
+6 +
+</pre>
+      </td>
+      <td class="source">
+        <pre><span class="noop">    pass
+</span><span class="noop">
+</span><span class="noop">def bar():
+</span><span class="hit">    a = &#39;a&#39;
+</span><span class="hit">    d = &#39;d&#39;
+</span></pre>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id="dummy/dummy2.py">dummy/dummy2.py</h4>
+<table class="code u-max-full-width">
+  <tbody>
+    <tr>
+      <td class="lineno">
+        <pre>1 &nbsp;
+2 +
+3 &nbsp;
+4 +
+5 &nbsp;
+</pre>
+      </td>
+      <td class="source">
+        <pre><span class="noop">def baz():
+</span><span class="hit">    c = &#39;c&#39;
+</span><span class="noop">
+</span><span class="hit">def bat():
+</span><span class="miss">    pass
+</span></pre>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<h4 id="dummy/dummy3.py">dummy/dummy3.py</h4>
+<table class="code u-max-full-width">
+  <tbody>
+    <tr>
+      <td class="lineno">
+        <pre>1 +
+2 +
+</pre>
+      </td>
+      <td class="source">
+        <pre><span class="miss">def foobar():
+</span><span class="miss">    pass  # This is a very long comment that was purposefully written so we could test how HTML rendering looks like when the boundaries of the page are reached. And here is a non-ascii char: \u015e
+</span></pre>
+      </td>
+    </tr>
+  </tbody>
+</table>
+    </div>
+  </body>
+</html>"""


### PR DESCRIPTION
Adds `show_missing` to `HtmlReporterDelta` to enable/disable the generation of the "Missing" column.

Closes #115