### PR TITLE
Draft: Feature/add markdown format

### DIFF
--- a/pycobertura/cli.py
+++ b/pycobertura/cli.py
@@ -7,7 +7,7 @@ from pycobertura.reporters import (
     JsonReporter,
     HtmlReporterDelta,
     TextReporterDelta,
-    JsonReporterDelta,
+    JsonReporterDelta
 )
 from pycobertura.filesystem import filesystem_factory
 from pycobertura.utils import get_dir_from_file_path

--- a/pycobertura/cli.py
+++ b/pycobertura/cli.py
@@ -7,7 +7,7 @@ from pycobertura.reporters import (
     JsonReporter,
     HtmlReporterDelta,
     TextReporterDelta,
-    JsonReporterDelta
+    JsonReporterDelta,
 )
 from pycobertura.filesystem import filesystem_factory
 from pycobertura.utils import get_dir_from_file_path

--- a/pycobertura/cli.py
+++ b/pycobertura/cli.py
@@ -4,6 +4,7 @@ from pycobertura.cobertura import Cobertura
 from pycobertura.reporters import (
     HtmlReporter,
     TextReporter,
+    MarkdownReporter,
     JsonReporter,
     HtmlReporterDelta,
     TextReporterDelta,
@@ -18,6 +19,7 @@ pycobertura = click.Group()
 reporters = {
     "html": HtmlReporter,
     "text": TextReporter,
+    "markdown": MarkdownReporter,
     "json": JsonReporter,
 }
 

--- a/pycobertura/reporters.py
+++ b/pycobertura/reporters.py
@@ -145,7 +145,7 @@ class DeltaReporter:
             else self.not_available
         )
 
-    def get_report_lines(self):
+    def get_report_lines(self, format_type="text"):
         diff_total_stmts = [
             self.differ.diff_total_statements(filename)
             for filename in self.differ.files()
@@ -178,25 +178,31 @@ class DeltaReporter:
         lines = {
             "Filename": filenames_of_files_with_changes,
             "Stmts": [
-                self.format_total_statements(diff_total_stmts[i])
+                self.format_total_statements(diff_total_stmts[i], format_type)
                 for i in indexes_of_files_with_changes
             ],
             "Miss": [
-                self.format_total_misses(diff_total_miss[i])
+                self.format_total_misses(diff_total_miss[i], format_type)
                 for i in indexes_of_files_with_changes
             ],
             "Cover": [
-                self.format_line_rate(diff_total_cover[i])
+                self.format_line_rate(diff_total_cover[i], format_type)
                 for i in indexes_of_files_with_changes
             ],
         }
 
         lines["Filename"].append("TOTAL")
         lines["Stmts"] += [
-            self.format_total_statements(self.differ.diff_total_statements())
+            self.format_total_statements(
+                self.differ.diff_total_statements(), format_type
+            )
         ]
-        lines["Miss"] += [self.format_total_misses(self.differ.diff_total_misses())]
-        lines["Cover"] += [self.format_line_rate(self.differ.diff_line_rate())]
+        lines["Miss"] += [
+            self.format_total_misses(self.differ.diff_total_misses(), format_type)
+        ]
+        lines["Cover"] += [
+            self.format_line_rate(self.differ.diff_line_rate(), format_type)
+        ]
 
         if self.show_source:
             diff_total_missing = [
@@ -234,7 +240,7 @@ class JsonReporterDelta(DeltaReporter):
         super(JsonReporterDelta, self).__init__(*args, **kwargs)
 
     def generate(self):
-        lines = self.get_report_lines()
+        lines = self.get_report_lines(format_type="json")
 
         if self.show_source:
             missed_lines_colored = [
@@ -243,9 +249,9 @@ class JsonReporterDelta(DeltaReporter):
             lines["Missing"] = missed_lines_colored
 
         rows = {k: v[:-1] for k, v in lines.items()}
-        footer = {k: v[-1] for k, v in lines.items()}
+        footer = {k: v[-1] for k, v in lines.items() if k != "Missing"}
 
-        json_string = json.dumps({"total": footer, "files": [rows]})
+        json_string = json.dumps({"total": footer, "files": [rows]}, indent=4)
 
         # for colors, explanation see here:
         # https://stackoverflow.com/a/61273717/9698518

--- a/pycobertura/reporters.py
+++ b/pycobertura/reporters.py
@@ -63,7 +63,7 @@ class JsonReporter(Reporter):
     def generate(self):
         lines = self.get_report_lines()
         rows = {k: v[:-1] for k, v in lines.items()}
-        footer = {k: v[-1] for k, v in lines.items()}
+        footer = {k: v[-1] for k, v in lines.items() if k!="Missing"}
 
         return json.dumps({"total": footer, "files": [rows]}, indent=4)
 

--- a/pycobertura/reporters.py
+++ b/pycobertura/reporters.py
@@ -63,7 +63,7 @@ class JsonReporter(Reporter):
     def generate(self):
         lines = self.get_report_lines()
         rows = {k: v[:-1] for k, v in lines.items()}
-        footer = {k: v[-1] for k, v in lines.items() if k!="Missing"}
+        footer = {k: v[-1] for k, v in lines.items() if k != "Missing"}
 
         return json.dumps({"total": footer, "files": [rows]}, indent=4)
 

--- a/pycobertura/reporters.py
+++ b/pycobertura/reporters.py
@@ -228,6 +228,7 @@ class TextReporterDelta(DeltaReporter):
 
         return tabulate(lines, headers=headers)
 
+
 class JsonReporterDelta(DeltaReporter):
     def __init__(self, *args, **kwargs):
         super(JsonReporterDelta, self).__init__(*args, **kwargs)

--- a/pycobertura/reporters.py
+++ b/pycobertura/reporters.py
@@ -145,7 +145,7 @@ class DeltaReporter:
             else self.not_available
         )
 
-    def get_report_lines(self, format_type="text"):
+    def get_report_lines(self):
         diff_total_stmts = [
             self.differ.diff_total_statements(filename)
             for filename in self.differ.files()
@@ -235,7 +235,7 @@ class JsonReporterDelta(DeltaReporter):
         super(JsonReporterDelta, self).__init__(*args, **kwargs)
 
     def generate(self):
-        lines = self.get_report_lines(format_type="json")
+        lines = self.get_report_lines()
 
         if self.show_source:
             missed_lines_colored = [

--- a/pycobertura/reporters.py
+++ b/pycobertura/reporters.py
@@ -228,6 +228,17 @@ class TextReporterDelta(DeltaReporter):
 
         return tabulate(lines, headers=headers)
 
+class JsonReporterDelta(DeltaReporter):
+    def __init__(self, *args, **kwargs):
+        super(JsonReporterDelta, self).__init__(*args, **kwargs)
+
+    def generate(self):
+        lines = self.get_report_lines()
+        rows = {k: v[:-1] for k, v in lines.items()}
+        footer = {k: v[-1] for k, v in lines.items()}
+
+        return json.dumps({"total": footer, "files": [rows]})
+
 
 class JsonReporterDelta(DeltaReporter):
     not_available = None

--- a/pycobertura/reporters.py
+++ b/pycobertura/reporters.py
@@ -235,10 +235,21 @@ class JsonReporterDelta(DeltaReporter):
 
     def generate(self):
         lines = self.get_report_lines()
+
+        if self.show_source:
+            missed_lines_colored = [
+                self.color_number(line) for line in lines["Missing"]
+            ]
+            lines["Missing"] = missed_lines_colored
+
         rows = {k: v[:-1] for k, v in lines.items()}
         footer = {k: v[-1] for k, v in lines.items()}
 
-        return json.dumps({"total": footer, "files": [rows]})
+        json_string = json.dumps({"total": footer, "files": [rows]})
+
+        return json_string.encode("utf-8").decode(
+            "unicode_escape"
+        )  # for colors, explanation see here: https://stackoverflow.com/a/61273717/9698518
 
 
 class JsonReporterDelta(DeltaReporter):

--- a/pycobertura/reporters.py
+++ b/pycobertura/reporters.py
@@ -63,9 +63,12 @@ class JsonReporter(Reporter):
     def generate(self):
         lines = self.get_report_lines()
         rows = {k: v[:-1] for k, v in lines.items()}
-        footer = {k: v[-1] for k, v in lines.items() if k != "Missing"}
-
-        return json.dumps({"total": footer, "files": rows}, indent=4)
+        footer = {k: v[-1] for k, v in lines.items()}
+        
+        return json.dumps({
+            "total": footer,
+            "files":[rows]
+        })
 
 
 class HtmlReporter(Reporter):

--- a/pycobertura/reporters.py
+++ b/pycobertura/reporters.py
@@ -58,6 +58,7 @@ class TextReporter(Reporter):
         lines = self.get_report_lines()
         return tabulate(lines, headers=headers_with_missing)
 
+
 class MarkdownReporter(Reporter):
     def generate(self):
         lines = self.get_report_lines()

--- a/pycobertura/reporters.py
+++ b/pycobertura/reporters.py
@@ -65,7 +65,7 @@ class JsonReporter(Reporter):
         rows = {k: v[:-1] for k, v in lines.items()}
         footer = {k: v[-1] for k, v in lines.items() if k != "Missing"}
 
-        return json.dumps({"total": footer, "files": [rows]}, indent=4)
+        return json.dumps({"total": footer, "files": rows}, indent=4)
 
 
 class HtmlReporter(Reporter):
@@ -244,7 +244,7 @@ class JsonReporterDelta(DeltaReporter):
         rows = {k: v[:-1] for k, v in lines.items()}
         footer = {k: v[-1] for k, v in lines.items() if k != "Missing"}
 
-        json_string = json.dumps({"total": footer, "files": [rows]}, indent=4)
+        json_string = json.dumps({"total": footer, "files": rows}, indent=4)
 
         # for colors, explanation see here:
         # https://stackoverflow.com/a/61273717/9698518

--- a/pycobertura/reporters.py
+++ b/pycobertura/reporters.py
@@ -247,9 +247,11 @@ class JsonReporterDelta(DeltaReporter):
 
         json_string = json.dumps({"total": footer, "files": [rows]})
 
-        return json_string.encode("utf-8").decode(
-            "unicode_escape"
-        )  # for colors, explanation see here: https://stackoverflow.com/a/61273717/9698518
+        # for colors, explanation see here:
+        # https://stackoverflow.com/a/61273717/9698518
+        colored_json_string = json_string.encode("utf-8").decode("unicode_escape")
+
+        return colored_json_string
 
 
 class JsonReporterDelta(DeltaReporter):

--- a/pycobertura/reporters.py
+++ b/pycobertura/reporters.py
@@ -230,9 +230,7 @@ class TextReporterDelta(DeltaReporter):
 
 
 class JsonReporterDelta(DeltaReporter):
-    def __init__(self, *args, **kwargs):
-        self.not_available = None
-        super(JsonReporterDelta, self).__init__(*args, **kwargs)
+    not_available = None
 
     def generate(self):
         lines = self.get_report_lines()
@@ -289,7 +287,6 @@ class HtmlReporterDelta(DeltaReporter):
         or not the generated report should contain a listing of missing lines in
         the summary table.
         """
-        self.not_available = "-"
         self.show_missing = kwargs.pop("show_missing", True)
         super(HtmlReporterDelta, self).__init__(*args, **kwargs)
 

--- a/pycobertura/reporters.py
+++ b/pycobertura/reporters.py
@@ -178,31 +178,25 @@ class DeltaReporter:
         lines = {
             "Filename": filenames_of_files_with_changes,
             "Stmts": [
-                self.format_total_statements(diff_total_stmts[i], format_type)
+                self.format_total_statements(diff_total_stmts[i])
                 for i in indexes_of_files_with_changes
             ],
             "Miss": [
-                self.format_total_misses(diff_total_miss[i], format_type)
+                self.format_total_misses(diff_total_miss[i])
                 for i in indexes_of_files_with_changes
             ],
             "Cover": [
-                self.format_line_rate(diff_total_cover[i], format_type)
+                self.format_line_rate(diff_total_cover[i])
                 for i in indexes_of_files_with_changes
             ],
         }
 
         lines["Filename"].append("TOTAL")
         lines["Stmts"] += [
-            self.format_total_statements(
-                self.differ.diff_total_statements(), format_type
-            )
+            self.format_total_statements(self.differ.diff_total_statements())
         ]
-        lines["Miss"] += [
-            self.format_total_misses(self.differ.diff_total_misses(), format_type)
-        ]
-        lines["Cover"] += [
-            self.format_line_rate(self.differ.diff_line_rate(), format_type)
-        ]
+        lines["Miss"] += [self.format_total_misses(self.differ.diff_total_misses())]
+        lines["Cover"] += [self.format_line_rate(self.differ.diff_line_rate())]
 
         if self.show_source:
             diff_total_missing = [
@@ -237,6 +231,7 @@ class TextReporterDelta(DeltaReporter):
 
 class JsonReporterDelta(DeltaReporter):
     def __init__(self, *args, **kwargs):
+        self.not_available = None
         super(JsonReporterDelta, self).__init__(*args, **kwargs)
 
     def generate(self):
@@ -294,6 +289,7 @@ class HtmlReporterDelta(DeltaReporter):
         or not the generated report should contain a listing of missing lines in
         the summary table.
         """
+        self.not_available = "-"
         self.show_missing = kwargs.pop("show_missing", True)
         super(HtmlReporterDelta, self).__init__(*args, **kwargs)
 

--- a/pycobertura/reporters.py
+++ b/pycobertura/reporters.py
@@ -58,6 +58,11 @@ class TextReporter(Reporter):
         lines = self.get_report_lines()
         return tabulate(lines, headers=headers_with_missing)
 
+class MarkdownReporter(Reporter):
+    def generate(self):
+        lines = self.get_report_lines()
+        return tabulate(lines, headers=headers_with_missing, tablefmt="github")
+
 
 class JsonReporter(Reporter):
     def generate(self):

--- a/pycobertura/reporters.py
+++ b/pycobertura/reporters.py
@@ -65,7 +65,7 @@ class JsonReporter(Reporter):
         rows = {k: v[:-1] for k, v in lines.items()}
         footer = {k: v[-1] for k, v in lines.items()}
 
-        return json.dumps({"total": footer, "files": [rows]})
+        return json.dumps({"total": footer, "files": [rows]}, indent=4)
 
 
 class HtmlReporter(Reporter):

--- a/pycobertura/reporters.py
+++ b/pycobertura/reporters.py
@@ -64,11 +64,8 @@ class JsonReporter(Reporter):
         lines = self.get_report_lines()
         rows = {k: v[:-1] for k, v in lines.items()}
         footer = {k: v[-1] for k, v in lines.items()}
-        
-        return json.dumps({
-            "total": footer,
-            "files":[rows]
-        })
+
+        return json.dumps({"total": footer, "files": [rows]})
 
 
 class HtmlReporter(Reporter):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -123,8 +123,7 @@ def test_show__format_json():
         "Filename": "TOTAL",
         "Stmts": 4,
         "Miss": 2,
-        "Cover": "50.00%",
-        "Missing": ""
+        "Cover": "50.00%"
     },
     "files": [
         {

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -125,33 +125,32 @@ def test_show__format_json():
         "Miss": 2,
         "Cover": "50.00%"
     },
-    "files": [
-        {
-            "Filename": [
-                "dummy/__init__.py",
-                "dummy/dummy.py"
-            ],
-            "Stmts": [
-                0,
-                4
-            ],
-            "Miss": [
-                0,
-                2
-            ],
-            "Cover": [
-                "0.00%",
-                "50.00%"
-            ],
-            "Missing": [
-                "",
-                "2, 5"
-            ]
-        }
-    ]
+    "files": {
+        "Filename": [
+            "dummy/__init__.py",
+            "dummy/dummy.py"
+        ],
+        "Stmts": [
+            0,
+            4
+        ],
+        "Miss": [
+            0,
+            2
+        ],
+        "Cover": [
+            "0.00%",
+            "50.00%"
+        ],
+        "Missing": [
+            "",
+            "2, 5"
+        ]
+    }
 }
 """
     assert result.exit_code == ExitCodes.OK
+
 
 def test_show__output_to_file():
     from pycobertura.cli import show, ExitCodes
@@ -265,6 +264,7 @@ def test_diff__format_json():
 """
     assert result.exit_code == ExitCodes.COVERAGE_WORSENED
 
+
 def test_diff__format_json():
     from pycobertura.cli import diff, ExitCodes
 
@@ -283,35 +283,33 @@ def test_diff__format_json():
         "Miss": "\u001b[31m+1\u001b[39m",
         "Cover": "+31.06%"
     },
-    "files": [
-        {
-            "Filename": [
-                "dummy/dummy.py",
-                "dummy/dummy2.py",
-                "dummy/dummy3.py"
-            ],
-            "Stmts": [
-                null,
-                "+2",
-                "+2"
-            ],
-            "Miss": [
-                "\u001b[32m-2\u001b[39m",
-                "\u001b[31m+1\u001b[39m",
-                "\u001b[31m+2\u001b[39m"
-            ],
-            "Cover": [
-                "+40.00%",
-                "-25.00%",
-                null
-            ],
-            "Missing": [
-                "\u001b[32m-5\u001b[39m, \u001b[32m-6\u001b[39m",
-                "\u001b[32m-2\u001b[39m, \u001b[32m-4\u001b[39m, \u001b[31m+5\u001b[39m",
-                "\u001b[31m+1\u001b[39m, \u001b[31m+2\u001b[39m"
-            ]
-        }
-    ]
+    "files": {
+        "Filename": [
+            "dummy/dummy.py",
+            "dummy/dummy2.py",
+            "dummy/dummy3.py"
+        ],
+        "Stmts": [
+            null,
+            "+2",
+            "+2"
+        ],
+        "Miss": [
+            "\u001b[32m-2\u001b[39m",
+            "\u001b[31m+1\u001b[39m",
+            "\u001b[31m+2\u001b[39m"
+        ],
+        "Cover": [
+            "+40.00%",
+            "-25.00%",
+            null
+        ],
+        "Missing": [
+            "\u001b[32m-5\u001b[39m, \u001b[32m-6\u001b[39m",
+            "\u001b[32m-2\u001b[39m, \u001b[32m-4\u001b[39m, \u001b[31m+5\u001b[39m",
+            "\u001b[31m+1\u001b[39m, \u001b[31m+2\u001b[39m"
+        ]
+    }
 }
 """
     assert result.exit_code == ExitCodes.COVERAGE_WORSENED
@@ -405,6 +403,7 @@ TOTAL            +4           +1  +31.06%
 """
     assert result.exit_code == ExitCodes.COVERAGE_WORSENED
 
+
 def test_diff__format_json__with_color():
     from pycobertura.cli import diff, ExitCodes
 
@@ -424,35 +423,33 @@ def test_diff__format_json__with_color():
         "Miss": "\u001b[31m+1\u001b[39m",
         "Cover": "+31.06%"
     },
-    "files": [
-        {
-            "Filename": [
-                "dummy/dummy.py",
-                "dummy/dummy2.py",
-                "dummy/dummy3.py"
-            ],
-            "Stmts": [
-                null,
-                "+2",
-                "+2"
-            ],
-            "Miss": [
-                "\u001b[32m-2\u001b[39m",
-                "\u001b[31m+1\u001b[39m",
-                "\u001b[31m+2\u001b[39m"
-            ],
-            "Cover": [
-                "+40.00%",
-                "-25.00%",
-                null
-            ],
-            "Missing": [
-                "\u001b[32m-5\u001b[39m, \u001b[32m-6\u001b[39m",
-                "\u001b[32m-2\u001b[39m, \u001b[32m-4\u001b[39m, \u001b[31m+5\u001b[39m",
-                "\u001b[31m+1\u001b[39m, \u001b[31m+2\u001b[39m"
-            ]
-        }
-    ]
+    "files": {
+        "Filename": [
+            "dummy/dummy.py",
+            "dummy/dummy2.py",
+            "dummy/dummy3.py"
+        ],
+        "Stmts": [
+            null,
+            "+2",
+            "+2"
+        ],
+        "Miss": [
+            "\u001b[32m-2\u001b[39m",
+            "\u001b[31m+1\u001b[39m",
+            "\u001b[31m+2\u001b[39m"
+        ],
+        "Cover": [
+            "+40.00%",
+            "-25.00%",
+            null
+        ],
+        "Missing": [
+            "\u001b[32m-5\u001b[39m, \u001b[32m-6\u001b[39m",
+            "\u001b[32m-2\u001b[39m, \u001b[32m-4\u001b[39m, \u001b[31m+5\u001b[39m",
+            "\u001b[31m+1\u001b[39m, \u001b[31m+2\u001b[39m"
+        ]
+    }
 }
 """
     assert result.exit_code == ExitCodes.COVERAGE_WORSENED
@@ -477,35 +474,33 @@ def test_diff__format_json__with_no_color():
         "Miss": "+1",
         "Cover": "+31.06%"
     },
-    "files": [
-        {
-            "Filename": [
-                "dummy/dummy.py",
-                "dummy/dummy2.py",
-                "dummy/dummy3.py"
-            ],
-            "Stmts": [
-                null,
-                "+2",
-                "+2"
-            ],
-            "Miss": [
-                "-2",
-                "+1",
-                "+2"
-            ],
-            "Cover": [
-                "+40.00%",
-                "-25.00%",
-                null
-            ],
-            "Missing": [
-                "-5, -6",
-                "-2, -4, +5",
-                "+1, +2"
-            ]
-        }
-    ]
+    "files": {
+        "Filename": [
+            "dummy/dummy.py",
+            "dummy/dummy2.py",
+            "dummy/dummy3.py"
+        ],
+        "Stmts": [
+            null,
+            "+2",
+            "+2"
+        ],
+        "Miss": [
+            "-2",
+            "+1",
+            "+2"
+        ],
+        "Cover": [
+            "+40.00%",
+            "-25.00%",
+            null
+        ],
+        "Missing": [
+            "-5, -6",
+            "-2, -4, +5",
+            "+1, +2"
+        ]
+    }
 }
 """
     assert result.exit_code == ExitCodes.COVERAGE_WORSENED

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -386,6 +386,25 @@ TOTAL            +4           \x1b[31m+1\x1b[39m  +31.06%
 """
     assert result.exit_code == ExitCodes.COVERAGE_WORSENED
 
+def test_diff__format_text__with_no_color():
+    from pycobertura.cli import diff, ExitCodes
+
+    runner = CliRunner()
+    result = runner.invoke(diff, [
+        '--no-color',
+        'tests/dummy.source1/coverage.xml',
+        'tests/dummy.source2/coverage.xml',
+    ], catch_exceptions=False)
+    assert result.output == """\
+Filename         Stmts      Miss  Cover    Missing
+---------------  -------  ------  -------  ----------
+dummy/dummy.py   -            -2  +40.00%  -5, -6
+dummy/dummy2.py  +2           +1  -25.00%  -2, -4, +5
+dummy/dummy3.py  +2           +2  -        +1, +2
+TOTAL            +4           +1  +31.06%
+"""
+    assert result.exit_code == ExitCodes.COVERAGE_WORSENED
+
 def test_diff__format_json__with_color():
     from pycobertura.cli import diff, ExitCodes
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -385,6 +385,7 @@ TOTAL            +4           \x1b[31m+1\x1b[39m  +31.06%
 """
     assert result.exit_code == ExitCodes.COVERAGE_WORSENED
 
+
 def test_diff__format_text__with_no_color():
     from pycobertura.cli import diff, ExitCodes
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -717,7 +717,6 @@ def test_diff__format_html__no_source():
     assert result.exit_code == ExitCodes.COVERAGE_WORSENED
 
 
-
 def test_diff__same_coverage_has_exit_status_of_zero():
     from pycobertura.cli import diff, ExitCodes
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -107,6 +107,53 @@ def test_show__format_json():
     assert result.exit_code == ExitCodes.OK
 
 
+def test_show__format_json():
+    from pycobertura.cli import show, ExitCodes
+
+    runner = CliRunner()
+    for opt in ('-f', '--format'):
+        result = runner.invoke(
+            show,
+            ['tests/dummy.original.xml', opt, 'json'],
+            catch_exceptions=False
+        )
+        assert result.output == """\
+{
+    "total": {
+        "Filename": "TOTAL",
+        "Stmts": 4,
+        "Miss": 2,
+        "Cover": "50.00%",
+        "Missing": ""
+    },
+    "files": [
+        {
+            "Filename": [
+                "dummy/__init__.py",
+                "dummy/dummy.py"
+            ],
+            "Stmts": [
+                0,
+                4
+            ],
+            "Miss": [
+                0,
+                2
+            ],
+            "Cover": [
+                "0.00%",
+                "50.00%"
+            ],
+            "Missing": [
+                "",
+                "2, 5"
+            ]
+        }
+    ]
+}
+"""
+    assert result.exit_code == ExitCodes.OK
+
 def test_show__output_to_file():
     from pycobertura.cli import show, ExitCodes
 
@@ -219,6 +266,57 @@ def test_diff__format_json():
 """
     assert result.exit_code == ExitCodes.COVERAGE_WORSENED
 
+def test_diff__format_json():
+    from pycobertura.cli import diff, ExitCodes
+
+    runner = CliRunner()
+    for opt in ('-f', '--format'):
+        result = runner.invoke(diff, [
+            opt, 'json',
+            'tests/dummy.source1/coverage.xml',
+            'tests/dummy.source2/coverage.xml',
+        ], catch_exceptions=False)
+        assert result.output == """\
+{
+    "total": {
+        "Filename": "TOTAL",
+        "Stmts": "+4",
+        "Miss": "\u001b[31m+1\u001b[39m",
+        "Cover": "+31.06%"
+    },
+    "files": [
+        {
+            "Filename": [
+                "dummy/dummy.py",
+                "dummy/dummy2.py",
+                "dummy/dummy3.py"
+            ],
+            "Stmts": [
+                null,
+                "+2",
+                "+2"
+            ],
+            "Miss": [
+                "\u001b[32m-2\u001b[39m",
+                "\u001b[31m+1\u001b[39m",
+                "\u001b[31m+2\u001b[39m"
+            ],
+            "Cover": [
+                "+40.00%",
+                "-25.00%",
+                null
+            ],
+            "Missing": [
+                "\u001b[32m-5\u001b[39m, \u001b[32m-6\u001b[39m",
+                "\u001b[32m-2\u001b[39m, \u001b[32m-4\u001b[39m, \u001b[31m+5\u001b[39m",
+                "\u001b[31m+1\u001b[39m, \u001b[31m+2\u001b[39m"
+            ]
+        }
+    ]
+}
+"""
+    assert result.exit_code == ExitCodes.COVERAGE_WORSENED
+
 
 def test_diff__output_to_file():
     from pycobertura.cli import diff, ExitCodes
@@ -288,8 +386,60 @@ TOTAL            +4           \x1b[31m+1\x1b[39m  +31.06%
 """
     assert result.exit_code == ExitCodes.COVERAGE_WORSENED
 
+def test_diff__format_json__with_color():
+    from pycobertura.cli import diff, ExitCodes
 
-def test_diff__format_text__with_no_color():
+    runner = CliRunner()
+    result = runner.invoke(diff, [
+        '--color',
+        'tests/dummy.source1/coverage.xml',
+        'tests/dummy.source2/coverage.xml',
+        '--format',
+        'json'
+    ], catch_exceptions=False)
+    assert result.output == """\
+{
+    "total": {
+        "Filename": "TOTAL",
+        "Stmts": "+4",
+        "Miss": "\u001b[31m+1\u001b[39m",
+        "Cover": "+31.06%"
+    },
+    "files": [
+        {
+            "Filename": [
+                "dummy/dummy.py",
+                "dummy/dummy2.py",
+                "dummy/dummy3.py"
+            ],
+            "Stmts": [
+                null,
+                "+2",
+                "+2"
+            ],
+            "Miss": [
+                "\u001b[32m-2\u001b[39m",
+                "\u001b[31m+1\u001b[39m",
+                "\u001b[31m+2\u001b[39m"
+            ],
+            "Cover": [
+                "+40.00%",
+                "-25.00%",
+                null
+            ],
+            "Missing": [
+                "\u001b[32m-5\u001b[39m, \u001b[32m-6\u001b[39m",
+                "\u001b[32m-2\u001b[39m, \u001b[32m-4\u001b[39m, \u001b[31m+5\u001b[39m",
+                "\u001b[31m+1\u001b[39m, \u001b[31m+2\u001b[39m"
+            ]
+        }
+    ]
+}
+"""
+    assert result.exit_code == ExitCodes.COVERAGE_WORSENED
+
+
+def test_diff__format_json__with_no_color():
     from pycobertura.cli import diff, ExitCodes
 
     runner = CliRunner()
@@ -297,14 +447,47 @@ def test_diff__format_text__with_no_color():
         '--no-color',
         'tests/dummy.source1/coverage.xml',
         'tests/dummy.source2/coverage.xml',
+        '--format',
+        'json'
     ], catch_exceptions=False)
     assert result.output == """\
-Filename         Stmts      Miss  Cover    Missing
----------------  -------  ------  -------  ----------
-dummy/dummy.py   -            -2  +40.00%  -5, -6
-dummy/dummy2.py  +2           +1  -25.00%  -2, -4, +5
-dummy/dummy3.py  +2           +2  -        +1, +2
-TOTAL            +4           +1  +31.06%
+{
+    "total": {
+        "Filename": "TOTAL",
+        "Stmts": "+4",
+        "Miss": "+1",
+        "Cover": "+31.06%"
+    },
+    "files": [
+        {
+            "Filename": [
+                "dummy/dummy.py",
+                "dummy/dummy2.py",
+                "dummy/dummy3.py"
+            ],
+            "Stmts": [
+                null,
+                "+2",
+                "+2"
+            ],
+            "Miss": [
+                "-2",
+                "+1",
+                "+2"
+            ],
+            "Cover": [
+                "+40.00%",
+                "-25.00%",
+                null
+            ],
+            "Missing": [
+                "-5, -6",
+                "-2, -4, +5",
+                "+1, +2"
+            ]
+        }
+    ]
+}
 """
     assert result.exit_code == ExitCodes.COVERAGE_WORSENED
 
@@ -513,6 +696,7 @@ def test_diff__format_html__no_source():
     assert result.output.startswith('<html>')
     assert result.output.endswith('</html>\n')
     assert result.exit_code == ExitCodes.COVERAGE_WORSENED
+
 
 
 def test_diff__same_coverage_has_exit_status_of_zero():


### PR DESCRIPTION
Add markdown format -> Draft. Happy for your input @aconrad.

Sample output:
```bash
$ pycobertura show --format "markdown" coverage.xml 
| Filename                          |   Stmts |   Miss | Cover   | Missing            |
|-----------------------------------|---------|--------|---------|--------------------|
| pycobertura/__init__.py           |       2 |      0 | 100.00% |                    |
| pycobertura/cli.py                |     132 |     88 | 33.33%  | 274-3758           |
| pycobertura/cobertura.py          |     216 |     35 | 83.80%  | 423, 648-696       |
| pycobertura/filesystem.py         |      91 |      6 | 93.41%  | 343-625            |
| pycobertura/reporters.py          |     222 |    114 | 48.65%  | 286, 290, 331-4065 |
| pycobertura/utils.py              |     122 |     15 | 87.70%  | 38, 262-486        |
| pycobertura/templates/__init__.py |       0 |      0 | 100.00% |                    |
| pycobertura/templates/filters.py  |      17 |     10 | 41.18%  | 261-544            |
| TOTAL                             |     802 |    268 | 66.58%  |                    |
```

This generates also a nice coverage.md:
```bash
pycobertura show --format "markdown" --output coverage.md coverage.xml 
```

Content of coverage.md:
```
| Filename                          |   Stmts |   Miss | Cover   | Missing            |
|-----------------------------------|---------|--------|---------|--------------------|
| pycobertura/__init__.py           |       2 |      0 | 100.00% |                    |
| pycobertura/cli.py                |     132 |     88 | 33.33%  | 274-3758           |
| pycobertura/cobertura.py          |     216 |     35 | 83.80%  | 423, 648-696       |
| pycobertura/filesystem.py         |      91 |      6 | 93.41%  | 343-625            |
| pycobertura/reporters.py          |     222 |    114 | 48.65%  | 286, 290, 331-4065 |
| pycobertura/utils.py              |     122 |     15 | 87.70%  | 38, 262-486        |
| pycobertura/templates/__init__.py |       0 |      0 | 100.00% |                    |
| pycobertura/templates/filters.py  |      17 |     10 | 41.18%  | 261-544            |
| TOTAL                             |     802 |    268 | 66.58%  |                    |
```