### PR TITLE
only return uncovered lines in Missing column

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@
   * Move formatting in `reporters.py` into `Reporter` and `DeltaReporter` base classes to have a uniform formatting: new `stringify` in `utils.py` method and corresponding test in `test_stringify.py`. The subclasses and only inherit from these two base classes to ensure a consistent formatting across the reporters
   * Change datastructure of coverage information from `namedtuple` (immutable) to `dictionary` (mutable) in `reporters.py`. Adjusted `html-delta.jinja2`, `html.jinja2` and `filters.py` accordingly. This change in datastructure leads to a more compact and more readable code
   * `pycobertura show` and `pycobertura diff` now support output formats: `json`, `markdown`, `csv`, and `yaml`.
+  * Only uncovered lines are reported in `Missing` column (instead of additionally reporting newly covered lines)
 
   Thanks @gro1m
 

--- a/pycobertura/cobertura.py
+++ b/pycobertura/cobertura.py
@@ -366,7 +366,7 @@ class CoberturaDiff:
         The given file `filename` where `lineno` is a missed line number.
         """
         return [
-            (line.number, True)
+            line.number
             for line in self.file_source(filename)
             if line.status is False
         ]

--- a/pycobertura/cobertura.py
+++ b/pycobertura/cobertura.py
@@ -362,17 +362,10 @@ class CoberturaDiff:
 
     def diff_missed_lines(self, filename):
         """
-        Return a list of 2-element tuples `(lineno, is_new)` for the given
-        file `filename` where `lineno` is a missed line number and `is_new`
-        indicates whether the missed line was introduced (True) or removed
-        (False).
+        Return a list of 2-element tuples `(lineno, True)` for uncovered lines. 
+        The given file `filename` where `lineno` is a missed line number.
         """
-        line_changed = []
-        for line in self.file_source(filename):
-            if line.status is not None:
-                is_new = not (line.status)
-                line_changed.append((line.number, is_new))
-        return line_changed
+        return [(line.number, True) for line in self.file_source(filename) if line.status is False]
 
     def files(self):
         """

--- a/pycobertura/cobertura.py
+++ b/pycobertura/cobertura.py
@@ -366,9 +366,7 @@ class CoberturaDiff:
         The given file `filename` where `lineno` is a missed line number.
         """
         return [
-            line.number
-            for line in self.file_source(filename)
-            if line.status is False
+            line.number for line in self.file_source(filename) if line.status is False
         ]
 
     def files(self):

--- a/pycobertura/cobertura.py
+++ b/pycobertura/cobertura.py
@@ -362,10 +362,14 @@ class CoberturaDiff:
 
     def diff_missed_lines(self, filename):
         """
-        Return a list of 2-element tuples `(lineno, True)` for uncovered lines. 
+        Return a list of 2-element tuples `(lineno, True)` for uncovered lines.
         The given file `filename` where `lineno` is a missed line number.
         """
-        return [(line.number, True) for line in self.file_source(filename) if line.status is False]
+        return [
+            (line.number, True)
+            for line in self.file_source(filename)
+            if line.status is False
+        ]
 
     def files(self):
         """

--- a/pycobertura/reporters.py
+++ b/pycobertura/reporters.py
@@ -148,11 +148,13 @@ class DeltaReporter:
 
     @staticmethod
     def format_missed_lines(missed_lines):
-        return [f"+{lno:d}" if is_new else f"-{lno:d}" for lno, is_new in missed_lines]
+        return [f"{lno:d}" for lno in missed_lines]
 
     @staticmethod
     def determine_ANSI_color_code_function_of_number(number):
-        return red if number.startswith("+") else green
+        if number.startswith("+") or number[0].isdigit():
+            return red 
+        return green
 
     @classmethod
     def convert_signed_number_to_ANSI_color_coded_signed_number(cls, number):

--- a/pycobertura/reporters.py
+++ b/pycobertura/reporters.py
@@ -153,7 +153,7 @@ class DeltaReporter:
     @staticmethod
     def determine_ANSI_color_code_function_of_number(number):
         if number.startswith("+") or number[0].isdigit():
-            return red 
+            return red
         return green
 
     @classmethod

--- a/pycobertura/templates/filters.py
+++ b/pycobertura/templates/filters.py
@@ -22,7 +22,9 @@ def is_not_equal_to_dash(arg):
 
 
 def misses_color(arg):
-    return "red" if arg.startswith("+") else "green"
+    if arg.startswith("+") or arg[0].isdigit():
+        return "red"
+    return "green"
 
 
 def line_status(line):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -251,8 +251,8 @@ def test_diff__format_default():
 Filename         Stmts      Miss  Cover    Missing
 ---------------  -------  ------  -------  ---------
 dummy/dummy.py   -            \x1b[32m-2\x1b[39m  +40.00%
-dummy/dummy2.py  +2           \x1b[31m+1\x1b[39m  -25.00%  \x1b[31m+5\x1b[39m
-dummy/dummy3.py  +2           \x1b[31m+2\x1b[39m  -        \x1b[31m+1\x1b[39m, \x1b[31m+2\x1b[39m
+dummy/dummy2.py  +2           \x1b[31m+1\x1b[39m  -25.00%  \x1b[31m5\x1b[39m
+dummy/dummy3.py  +2           \x1b[31m+2\x1b[39m  -        \x1b[31m1\x1b[39m, \x1b[31m2\x1b[39m
 TOTAL            +4           \x1b[31m+1\x1b[39m  +31.06%
 """
     assert result.exit_code == ExitCodes.COVERAGE_WORSENED
@@ -272,8 +272,8 @@ def test_diff__format_text():
 Filename         Stmts      Miss  Cover    Missing
 ---------------  -------  ------  -------  ---------
 dummy/dummy.py   -            \x1b[32m-2\x1b[39m  +40.00%
-dummy/dummy2.py  +2           \x1b[31m+1\x1b[39m  -25.00%  \x1b[31m+5\x1b[39m
-dummy/dummy3.py  +2           \x1b[31m+2\x1b[39m  -        \x1b[31m+1\x1b[39m, \x1b[31m+2\x1b[39m
+dummy/dummy2.py  +2           \x1b[31m+1\x1b[39m  -25.00%  \x1b[31m5\x1b[39m
+dummy/dummy3.py  +2           \x1b[31m+2\x1b[39m  -        \x1b[31m1\x1b[39m, \x1b[31m2\x1b[39m
 TOTAL            +4           \x1b[31m+1\x1b[39m  +31.06%
 """
     assert result.exit_code == ExitCodes.COVERAGE_WORSENED
@@ -291,8 +291,8 @@ def test_diff__format_csv():
         assert result.output == """\
 Filename;Stmts;Miss;Cover;Missing
 dummy/dummy.py;;\x1b[32m-2\x1b[39m;+40.00%;[]
-dummy/dummy2.py;+2;\x1b[31m+1\x1b[39m;-25.00%;['\x1b[31m+5\x1b[39m']
-dummy/dummy3.py;+2;\x1b[31m+2\x1b[39m;;['\x1b[31m+1\x1b[39m', '\x1b[31m+2\x1b[39m']
+dummy/dummy2.py;+2;\x1b[31m+1\x1b[39m;-25.00%;['\x1b[31m5\x1b[39m']
+dummy/dummy3.py;+2;\x1b[31m+2\x1b[39m;;['\x1b[31m1\x1b[39m', '\x1b[31m2\x1b[39m']
 TOTAL;+4;\x1b[31m+1\x1b[39m;+31.06%;[]
 """
     assert result.exit_code == ExitCodes.COVERAGE_WORSENED
@@ -312,8 +312,8 @@ def test_diff__format_csv_delimiter_semicolon():
         assert result.output == """\
 Filename;Stmts;Miss;Cover;Missing
 dummy/dummy.py;;\x1b[32m-2\x1b[39m;+40.00%;[]
-dummy/dummy2.py;+2;\x1b[31m+1\x1b[39m;-25.00%;['\x1b[31m+5\x1b[39m']
-dummy/dummy3.py;+2;\x1b[31m+2\x1b[39m;;['\x1b[31m+1\x1b[39m', '\x1b[31m+2\x1b[39m']
+dummy/dummy2.py;+2;\x1b[31m+1\x1b[39m;-25.00%;['\x1b[31m5\x1b[39m']
+dummy/dummy3.py;+2;\x1b[31m+2\x1b[39m;;['\x1b[31m1\x1b[39m', '\x1b[31m2\x1b[39m']
 TOTAL;+4;\x1b[31m+1\x1b[39m;+31.06%;[]
 """
     assert result.exit_code == ExitCodes.COVERAGE_WORSENED
@@ -333,8 +333,8 @@ def test_diff__format_csv_delimiter_tab():
         assert result.output == """\
 Filename\tStmts\tMiss\tCover\tMissing
 dummy/dummy.py\t\t\x1b[32m-2\x1b[39m\t+40.00%\t[]
-dummy/dummy2.py\t+2\t\x1b[31m+1\x1b[39m\t-25.00%\t['\x1b[31m+5\x1b[39m']
-dummy/dummy3.py\t+2\t\x1b[31m+2\x1b[39m\t\t['\x1b[31m+1\x1b[39m', '\x1b[31m+2\x1b[39m']
+dummy/dummy2.py\t+2\t\x1b[31m+1\x1b[39m\t-25.00%\t['\x1b[31m5\x1b[39m']
+dummy/dummy3.py\t+2\t\x1b[31m+2\x1b[39m\t\t['\x1b[31m1\x1b[39m', '\x1b[31m2\x1b[39m']
 TOTAL\t+4\t\x1b[31m+1\x1b[39m\t+31.06%\t[]
 """
     assert result.exit_code == ExitCodes.COVERAGE_WORSENED
@@ -353,8 +353,8 @@ def test_diff__format_markdown():
 | Filename        | Stmts   |   Miss | Cover   | Missing   |
 |-----------------|---------|--------|---------|-----------|
 | dummy/dummy.py  | -       |     \x1b[32m-2\x1b[39m | +40.00% |           |
-| dummy/dummy2.py | +2      |     \x1b[31m+1\x1b[39m | -25.00% | \x1b[31m+5\x1b[39m        |
-| dummy/dummy3.py | +2      |     \x1b[31m+2\x1b[39m | -       | \x1b[31m+1\x1b[39m, \x1b[31m+2\x1b[39m    |
+| dummy/dummy2.py | +2      |     \x1b[31m+1\x1b[39m | -25.00% | \x1b[31m5\x1b[39m         |
+| dummy/dummy3.py | +2      |     \x1b[31m+2\x1b[39m | -       | \x1b[31m1\x1b[39m, \x1b[31m2\x1b[39m      |
 | TOTAL           | +4      |     \x1b[31m+1\x1b[39m | +31.06% |           |
 """
     assert result.exit_code == ExitCodes.COVERAGE_WORSENED
@@ -401,8 +401,8 @@ def test_diff__format_json():
         ],
         "Missing": [
             "",
-            "\u001b[31m+5\u001b[39m",
-            "\u001b[31m+1\u001b[39m, \u001b[31m+2\u001b[39m"
+            "\u001b[31m5\u001b[39m",
+            "\u001b[31m1\u001b[39m, \u001b[31m2\u001b[39m"
         ]
     }
 }
@@ -444,8 +444,8 @@ files:
   - 
   Missing:
   - ''
-  - "\x1b[31m+5\x1b[39m"
-  - "\x1b[31m+1\x1b[39m, \x1b[31m+2\x1b[39m"
+  - "\x1b[31m5\x1b[39m"
+  - "\x1b[31m1\x1b[39m, \x1b[31m2\x1b[39m"
 
 """
     assert result.exit_code == ExitCodes.COVERAGE_WORSENED
@@ -470,8 +470,8 @@ def test_diff__output_to_file():
 Filename         Stmts      Miss  Cover    Missing
 ---------------  -------  ------  -------  ---------
 dummy/dummy.py   -            -2  +40.00%
-dummy/dummy2.py  +2           +1  -25.00%  +5
-dummy/dummy3.py  +2           +2  -        +1, +2
+dummy/dummy2.py  +2           +1  -25.00%  5
+dummy/dummy3.py  +2           +2  -        1, 2
 TOTAL            +4           +1  +31.06%"""
     assert result.exit_code == ExitCodes.COVERAGE_WORSENED
 
@@ -494,8 +494,8 @@ def test_diff__output_to_file__force_color():
 Filename         Stmts      Miss  Cover    Missing
 ---------------  -------  ------  -------  ---------
 dummy/dummy.py   -            \x1b[32m-2\x1b[39m  +40.00%
-dummy/dummy2.py  +2           \x1b[31m+1\x1b[39m  -25.00%  \x1b[31m+5\x1b[39m
-dummy/dummy3.py  +2           \x1b[31m+2\x1b[39m  -        \x1b[31m+1\x1b[39m, \x1b[31m+2\x1b[39m
+dummy/dummy2.py  +2           \x1b[31m+1\x1b[39m  -25.00%  \x1b[31m5\x1b[39m
+dummy/dummy3.py  +2           \x1b[31m+2\x1b[39m  -        \x1b[31m1\x1b[39m, \x1b[31m2\x1b[39m
 TOTAL            +4           \x1b[31m+1\x1b[39m  +31.06%"""
     assert result.exit_code == ExitCodes.COVERAGE_WORSENED
 
@@ -513,8 +513,8 @@ def test_diff__format_text__with_color():
 Filename         Stmts      Miss  Cover    Missing
 ---------------  -------  ------  -------  ---------
 dummy/dummy.py   -            \x1b[32m-2\x1b[39m  +40.00%
-dummy/dummy2.py  +2           \x1b[31m+1\x1b[39m  -25.00%  \x1b[31m+5\x1b[39m
-dummy/dummy3.py  +2           \x1b[31m+2\x1b[39m  -        \x1b[31m+1\x1b[39m, \x1b[31m+2\x1b[39m
+dummy/dummy2.py  +2           \x1b[31m+1\x1b[39m  -25.00%  \x1b[31m5\x1b[39m
+dummy/dummy3.py  +2           \x1b[31m+2\x1b[39m  -        \x1b[31m1\x1b[39m, \x1b[31m2\x1b[39m
 TOTAL            +4           \x1b[31m+1\x1b[39m  +31.06%
 """
     assert result.exit_code == ExitCodes.COVERAGE_WORSENED
@@ -533,8 +533,8 @@ def test_diff__format_text__with_no_color():
 Filename         Stmts      Miss  Cover    Missing
 ---------------  -------  ------  -------  ---------
 dummy/dummy.py   -            -2  +40.00%
-dummy/dummy2.py  +2           +1  -25.00%  +5
-dummy/dummy3.py  +2           +2  -        +1, +2
+dummy/dummy2.py  +2           +1  -25.00%  5
+dummy/dummy3.py  +2           +2  -        1, 2
 TOTAL            +4           +1  +31.06%
 """
     assert result.exit_code == ExitCodes.COVERAGE_WORSENED
@@ -554,8 +554,8 @@ def test_diff__format_markdown__with_color():
 | Filename        | Stmts   |   Miss | Cover   | Missing   |
 |-----------------|---------|--------|---------|-----------|
 | dummy/dummy.py  | -       |     \x1b[32m-2\x1b[39m | +40.00% |           |
-| dummy/dummy2.py | +2      |     \x1b[31m+1\x1b[39m | -25.00% | \x1b[31m+5\x1b[39m        |
-| dummy/dummy3.py | +2      |     \x1b[31m+2\x1b[39m | -       | \x1b[31m+1\x1b[39m, \x1b[31m+2\x1b[39m    |
+| dummy/dummy2.py | +2      |     \x1b[31m+1\x1b[39m | -25.00% | \x1b[31m5\x1b[39m         |
+| dummy/dummy3.py | +2      |     \x1b[31m+2\x1b[39m | -       | \x1b[31m1\x1b[39m, \x1b[31m2\x1b[39m      |
 | TOTAL           | +4      |     \x1b[31m+1\x1b[39m | +31.06% |           |
 """
     assert result.exit_code == ExitCodes.COVERAGE_WORSENED
@@ -575,8 +575,8 @@ def test_diff__format_markdown__with_no_color():
 | Filename        | Stmts   |   Miss | Cover   | Missing   |
 |-----------------|---------|--------|---------|-----------|
 | dummy/dummy.py  | -       |     -2 | +40.00% |           |
-| dummy/dummy2.py | +2      |     +1 | -25.00% | +5        |
-| dummy/dummy3.py | +2      |     +2 | -       | +1, +2    |
+| dummy/dummy2.py | +2      |     +1 | -25.00% | 5         |
+| dummy/dummy3.py | +2      |     +2 | -       | 1, 2      |
 | TOTAL           | +4      |     +1 | +31.06% |           |
 """
     assert result.exit_code == ExitCodes.COVERAGE_WORSENED
@@ -624,8 +624,8 @@ def test_diff__format_json__with_color():
         ],
         "Missing": [
             "",
-            "\u001b[31m+5\u001b[39m",
-            "\u001b[31m+1\u001b[39m, \u001b[31m+2\u001b[39m"
+            "\u001b[31m5\u001b[39m",
+            "\u001b[31m1\u001b[39m, \u001b[31m2\u001b[39m"
         ]
     }
 }
@@ -675,8 +675,8 @@ def test_diff__format_json__with_no_color():
         ],
         "Missing": [
             "",
-            "+5",
-            "+1, +2"
+            "5",
+            "1, 2"
         ]
     }
 }
@@ -719,8 +719,8 @@ files:
   - 
   Missing:
   - ''
-  - "\x1b[31m+5\x1b[39m"
-  - "\x1b[31m+1\x1b[39m, \x1b[31m+2\x1b[39m"
+  - "\x1b[31m5\x1b[39m"
+  - "\x1b[31m1\x1b[39m, \x1b[31m2\x1b[39m"
 
 """
     assert result.exit_code == ExitCodes.COVERAGE_WORSENED
@@ -761,8 +761,8 @@ files:
   - 
   Missing:
   - ''
-  - '+5'
-  - +1, +2
+  - '5'
+  - 1, 2
 
 """
     assert result.exit_code == ExitCodes.COVERAGE_WORSENED

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -249,9 +249,9 @@ def test_diff__format_default():
     ], catch_exceptions=False)
     assert result.output == """\
 Filename         Stmts      Miss  Cover    Missing
----------------  -------  ------  -------  ----------
-dummy/dummy.py   -            \x1b[32m-2\x1b[39m  +40.00%  \x1b[32m-5\x1b[39m, \x1b[32m-6\x1b[39m
-dummy/dummy2.py  +2           \x1b[31m+1\x1b[39m  -25.00%  \x1b[32m-2\x1b[39m, \x1b[32m-4\x1b[39m, \x1b[31m+5\x1b[39m
+---------------  -------  ------  -------  ---------
+dummy/dummy.py   -            \x1b[32m-2\x1b[39m  +40.00%
+dummy/dummy2.py  +2           \x1b[31m+1\x1b[39m  -25.00%  \x1b[31m+5\x1b[39m
 dummy/dummy3.py  +2           \x1b[31m+2\x1b[39m  -        \x1b[31m+1\x1b[39m, \x1b[31m+2\x1b[39m
 TOTAL            +4           \x1b[31m+1\x1b[39m  +31.06%
 """
@@ -270,9 +270,9 @@ def test_diff__format_text():
         ], catch_exceptions=False)
         assert result.output == """\
 Filename         Stmts      Miss  Cover    Missing
----------------  -------  ------  -------  ----------
-dummy/dummy.py   -            \x1b[32m-2\x1b[39m  +40.00%  \x1b[32m-5\x1b[39m, \x1b[32m-6\x1b[39m
-dummy/dummy2.py  +2           \x1b[31m+1\x1b[39m  -25.00%  \x1b[32m-2\x1b[39m, \x1b[32m-4\x1b[39m, \x1b[31m+5\x1b[39m
+---------------  -------  ------  -------  ---------
+dummy/dummy.py   -            \x1b[32m-2\x1b[39m  +40.00%
+dummy/dummy2.py  +2           \x1b[31m+1\x1b[39m  -25.00%  \x1b[31m+5\x1b[39m
 dummy/dummy3.py  +2           \x1b[31m+2\x1b[39m  -        \x1b[31m+1\x1b[39m, \x1b[31m+2\x1b[39m
 TOTAL            +4           \x1b[31m+1\x1b[39m  +31.06%
 """
@@ -290,8 +290,8 @@ def test_diff__format_csv():
         ], catch_exceptions=False)
         assert result.output == """\
 Filename;Stmts;Miss;Cover;Missing
-dummy/dummy.py;;\x1b[32m-2\x1b[39m;+40.00%;['\x1b[32m-5\x1b[39m', '\x1b[32m-6\x1b[39m']
-dummy/dummy2.py;+2;\x1b[31m+1\x1b[39m;-25.00%;['\x1b[32m-2\x1b[39m', '\x1b[32m-4\x1b[39m', '\x1b[31m+5\x1b[39m']
+dummy/dummy.py;;\x1b[32m-2\x1b[39m;+40.00%;[]
+dummy/dummy2.py;+2;\x1b[31m+1\x1b[39m;-25.00%;['\x1b[31m+5\x1b[39m']
 dummy/dummy3.py;+2;\x1b[31m+2\x1b[39m;;['\x1b[31m+1\x1b[39m', '\x1b[31m+2\x1b[39m']
 TOTAL;+4;\x1b[31m+1\x1b[39m;+31.06%;[]
 """
@@ -311,8 +311,8 @@ def test_diff__format_csv_delimiter_semicolon():
         ], catch_exceptions=False)
         assert result.output == """\
 Filename;Stmts;Miss;Cover;Missing
-dummy/dummy.py;;\x1b[32m-2\x1b[39m;+40.00%;['\x1b[32m-5\x1b[39m', '\x1b[32m-6\x1b[39m']
-dummy/dummy2.py;+2;\x1b[31m+1\x1b[39m;-25.00%;['\x1b[32m-2\x1b[39m', '\x1b[32m-4\x1b[39m', '\x1b[31m+5\x1b[39m']
+dummy/dummy.py;;\x1b[32m-2\x1b[39m;+40.00%;[]
+dummy/dummy2.py;+2;\x1b[31m+1\x1b[39m;-25.00%;['\x1b[31m+5\x1b[39m']
 dummy/dummy3.py;+2;\x1b[31m+2\x1b[39m;;['\x1b[31m+1\x1b[39m', '\x1b[31m+2\x1b[39m']
 TOTAL;+4;\x1b[31m+1\x1b[39m;+31.06%;[]
 """
@@ -332,8 +332,8 @@ def test_diff__format_csv_delimiter_tab():
             ], catch_exceptions=False)
         assert result.output == """\
 Filename\tStmts\tMiss\tCover\tMissing
-dummy/dummy.py\t\t\x1b[32m-2\x1b[39m\t+40.00%\t['\x1b[32m-5\x1b[39m', '\x1b[32m-6\x1b[39m']
-dummy/dummy2.py\t+2\t\x1b[31m+1\x1b[39m\t-25.00%\t['\x1b[32m-2\x1b[39m', '\x1b[32m-4\x1b[39m', '\x1b[31m+5\x1b[39m']
+dummy/dummy.py\t\t\x1b[32m-2\x1b[39m\t+40.00%\t[]
+dummy/dummy2.py\t+2\t\x1b[31m+1\x1b[39m\t-25.00%\t['\x1b[31m+5\x1b[39m']
 dummy/dummy3.py\t+2\t\x1b[31m+2\x1b[39m\t\t['\x1b[31m+1\x1b[39m', '\x1b[31m+2\x1b[39m']
 TOTAL\t+4\t\x1b[31m+1\x1b[39m\t+31.06%\t[]
 """
@@ -350,12 +350,12 @@ def test_diff__format_markdown():
             'tests/dummy.source2/coverage.xml',
         ], catch_exceptions=False)
     assert result.output == """\
-| Filename        | Stmts   |   Miss | Cover   | Missing    |
-|-----------------|---------|--------|---------|------------|
-| dummy/dummy.py  | -       |     \x1b[32m-2\x1b[39m | +40.00% | \x1b[32m-5\x1b[39m, \x1b[32m-6\x1b[39m     |
-| dummy/dummy2.py | +2      |     \x1b[31m+1\x1b[39m | -25.00% | \x1b[32m-2\x1b[39m, \x1b[32m-4\x1b[39m, \x1b[31m+5\x1b[39m |
-| dummy/dummy3.py | +2      |     \x1b[31m+2\x1b[39m | -       | \x1b[31m+1\x1b[39m, \x1b[31m+2\x1b[39m     |
-| TOTAL           | +4      |     \x1b[31m+1\x1b[39m | +31.06% |            |
+| Filename        | Stmts   |   Miss | Cover   | Missing   |
+|-----------------|---------|--------|---------|-----------|
+| dummy/dummy.py  | -       |     \x1b[32m-2\x1b[39m | +40.00% |           |
+| dummy/dummy2.py | +2      |     \x1b[31m+1\x1b[39m | -25.00% | \x1b[31m+5\x1b[39m        |
+| dummy/dummy3.py | +2      |     \x1b[31m+2\x1b[39m | -       | \x1b[31m+1\x1b[39m, \x1b[31m+2\x1b[39m    |
+| TOTAL           | +4      |     \x1b[31m+1\x1b[39m | +31.06% |           |
 """
     assert result.exit_code == ExitCodes.COVERAGE_WORSENED
 
@@ -400,8 +400,8 @@ def test_diff__format_json():
             null
         ],
         "Missing": [
-            "\u001b[32m-5\u001b[39m, \u001b[32m-6\u001b[39m",
-            "\u001b[32m-2\u001b[39m, \u001b[32m-4\u001b[39m, \u001b[31m+5\u001b[39m",
+            "",
+            "\u001b[31m+5\u001b[39m",
             "\u001b[31m+1\u001b[39m, \u001b[31m+2\u001b[39m"
         ]
     }
@@ -443,8 +443,8 @@ files:
   - -25.00%
   - 
   Missing:
-  - "\x1b[32m-5\x1b[39m, \x1b[32m-6\x1b[39m"
-  - "\x1b[32m-2\x1b[39m, \x1b[32m-4\x1b[39m, \x1b[31m+5\x1b[39m"
+  - ''
+  - "\x1b[31m+5\x1b[39m"
   - "\x1b[31m+1\x1b[39m, \x1b[31m+2\x1b[39m"
 
 """
@@ -468,9 +468,9 @@ def test_diff__output_to_file():
         assert result.output == ""
         assert report == """\
 Filename         Stmts      Miss  Cover    Missing
----------------  -------  ------  -------  ----------
-dummy/dummy.py   -            -2  +40.00%  -5, -6
-dummy/dummy2.py  +2           +1  -25.00%  -2, -4, +5
+---------------  -------  ------  -------  ---------
+dummy/dummy.py   -            -2  +40.00%
+dummy/dummy2.py  +2           +1  -25.00%  +5
 dummy/dummy3.py  +2           +2  -        +1, +2
 TOTAL            +4           +1  +31.06%"""
     assert result.exit_code == ExitCodes.COVERAGE_WORSENED
@@ -492,9 +492,9 @@ def test_diff__output_to_file__force_color():
     assert result.output == ""
     assert report == """\
 Filename         Stmts      Miss  Cover    Missing
----------------  -------  ------  -------  ----------
-dummy/dummy.py   -            \x1b[32m-2\x1b[39m  +40.00%  \x1b[32m-5\x1b[39m, \x1b[32m-6\x1b[39m
-dummy/dummy2.py  +2           \x1b[31m+1\x1b[39m  -25.00%  \x1b[32m-2\x1b[39m, \x1b[32m-4\x1b[39m, \x1b[31m+5\x1b[39m
+---------------  -------  ------  -------  ---------
+dummy/dummy.py   -            \x1b[32m-2\x1b[39m  +40.00%
+dummy/dummy2.py  +2           \x1b[31m+1\x1b[39m  -25.00%  \x1b[31m+5\x1b[39m
 dummy/dummy3.py  +2           \x1b[31m+2\x1b[39m  -        \x1b[31m+1\x1b[39m, \x1b[31m+2\x1b[39m
 TOTAL            +4           \x1b[31m+1\x1b[39m  +31.06%"""
     assert result.exit_code == ExitCodes.COVERAGE_WORSENED
@@ -511,9 +511,9 @@ def test_diff__format_text__with_color():
     ], catch_exceptions=False)
     assert result.output == """\
 Filename         Stmts      Miss  Cover    Missing
----------------  -------  ------  -------  ----------
-dummy/dummy.py   -            \x1b[32m-2\x1b[39m  +40.00%  \x1b[32m-5\x1b[39m, \x1b[32m-6\x1b[39m
-dummy/dummy2.py  +2           \x1b[31m+1\x1b[39m  -25.00%  \x1b[32m-2\x1b[39m, \x1b[32m-4\x1b[39m, \x1b[31m+5\x1b[39m
+---------------  -------  ------  -------  ---------
+dummy/dummy.py   -            \x1b[32m-2\x1b[39m  +40.00%
+dummy/dummy2.py  +2           \x1b[31m+1\x1b[39m  -25.00%  \x1b[31m+5\x1b[39m
 dummy/dummy3.py  +2           \x1b[31m+2\x1b[39m  -        \x1b[31m+1\x1b[39m, \x1b[31m+2\x1b[39m
 TOTAL            +4           \x1b[31m+1\x1b[39m  +31.06%
 """
@@ -531,9 +531,9 @@ def test_diff__format_text__with_no_color():
     ], catch_exceptions=False)
     assert result.output == """\
 Filename         Stmts      Miss  Cover    Missing
----------------  -------  ------  -------  ----------
-dummy/dummy.py   -            -2  +40.00%  -5, -6
-dummy/dummy2.py  +2           +1  -25.00%  -2, -4, +5
+---------------  -------  ------  -------  ---------
+dummy/dummy.py   -            -2  +40.00%
+dummy/dummy2.py  +2           +1  -25.00%  +5
 dummy/dummy3.py  +2           +2  -        +1, +2
 TOTAL            +4           +1  +31.06%
 """
@@ -551,12 +551,12 @@ def test_diff__format_markdown__with_color():
         'markdown',
     ], catch_exceptions=False)
     assert result.output == """\
-| Filename        | Stmts   |   Miss | Cover   | Missing    |
-|-----------------|---------|--------|---------|------------|
-| dummy/dummy.py  | -       |     \x1b[32m-2\x1b[39m | +40.00% | \x1b[32m-5\x1b[39m, \x1b[32m-6\x1b[39m     |
-| dummy/dummy2.py | +2      |     \x1b[31m+1\x1b[39m | -25.00% | \x1b[32m-2\x1b[39m, \x1b[32m-4\x1b[39m, \x1b[31m+5\x1b[39m |
-| dummy/dummy3.py | +2      |     \x1b[31m+2\x1b[39m | -       | \x1b[31m+1\x1b[39m, \x1b[31m+2\x1b[39m     |
-| TOTAL           | +4      |     \x1b[31m+1\x1b[39m | +31.06% |            |
+| Filename        | Stmts   |   Miss | Cover   | Missing   |
+|-----------------|---------|--------|---------|-----------|
+| dummy/dummy.py  | -       |     \x1b[32m-2\x1b[39m | +40.00% |           |
+| dummy/dummy2.py | +2      |     \x1b[31m+1\x1b[39m | -25.00% | \x1b[31m+5\x1b[39m        |
+| dummy/dummy3.py | +2      |     \x1b[31m+2\x1b[39m | -       | \x1b[31m+1\x1b[39m, \x1b[31m+2\x1b[39m    |
+| TOTAL           | +4      |     \x1b[31m+1\x1b[39m | +31.06% |           |
 """
     assert result.exit_code == ExitCodes.COVERAGE_WORSENED
 
@@ -572,12 +572,12 @@ def test_diff__format_markdown__with_no_color():
         'markdown',
     ], catch_exceptions=False)
     assert result.output == """\
-| Filename        | Stmts   |   Miss | Cover   | Missing    |
-|-----------------|---------|--------|---------|------------|
-| dummy/dummy.py  | -       |     -2 | +40.00% | -5, -6     |
-| dummy/dummy2.py | +2      |     +1 | -25.00% | -2, -4, +5 |
-| dummy/dummy3.py | +2      |     +2 | -       | +1, +2     |
-| TOTAL           | +4      |     +1 | +31.06% |            |
+| Filename        | Stmts   |   Miss | Cover   | Missing   |
+|-----------------|---------|--------|---------|-----------|
+| dummy/dummy.py  | -       |     -2 | +40.00% |           |
+| dummy/dummy2.py | +2      |     +1 | -25.00% | +5        |
+| dummy/dummy3.py | +2      |     +2 | -       | +1, +2    |
+| TOTAL           | +4      |     +1 | +31.06% |           |
 """
     assert result.exit_code == ExitCodes.COVERAGE_WORSENED
 
@@ -623,8 +623,8 @@ def test_diff__format_json__with_color():
             null
         ],
         "Missing": [
-            "\u001b[32m-5\u001b[39m, \u001b[32m-6\u001b[39m",
-            "\u001b[32m-2\u001b[39m, \u001b[32m-4\u001b[39m, \u001b[31m+5\u001b[39m",
+            "",
+            "\u001b[31m+5\u001b[39m",
             "\u001b[31m+1\u001b[39m, \u001b[31m+2\u001b[39m"
         ]
     }
@@ -674,8 +674,8 @@ def test_diff__format_json__with_no_color():
             null
         ],
         "Missing": [
-            "-5, -6",
-            "-2, -4, +5",
+            "",
+            "+5",
             "+1, +2"
         ]
     }
@@ -718,8 +718,8 @@ files:
   - -25.00%
   - 
   Missing:
-  - "\x1b[32m-5\x1b[39m, \x1b[32m-6\x1b[39m"
-  - "\x1b[32m-2\x1b[39m, \x1b[32m-4\x1b[39m, \x1b[31m+5\x1b[39m"
+  - ''
+  - "\x1b[31m+5\x1b[39m"
   - "\x1b[31m+1\x1b[39m, \x1b[31m+2\x1b[39m"
 
 """
@@ -760,8 +760,8 @@ files:
   - -25.00%
   - 
   Missing:
-  - -5, -6
-  - -2, -4, +5
+  - ''
+  - '+5'
   - +1, +2
 
 """

--- a/tests/test_cobertura_diff.py
+++ b/tests/test_cobertura_diff.py
@@ -102,7 +102,7 @@ def test_diff_same_report_different_source_dirs():
     cobertura2 = make_cobertura('tests/dummy.uncovered.addcode/coverage.xml', source='tests/dummy.uncovered.addcode/dummy/')
     differ = CoberturaDiff(cobertura1, cobertura2)
 
-    assert differ.diff_missed_lines('dummy.py') == [(3, True)]
+    assert differ.diff_missed_lines('dummy.py') == [3]
 
 
 def test_diff_total_hits():

--- a/tests/test_cobertura_diff.py
+++ b/tests/test_cobertura_diff.py
@@ -102,7 +102,7 @@ def test_diff_same_report_different_source_dirs():
     cobertura2 = make_cobertura('tests/dummy.uncovered.addcode/coverage.xml', source='tests/dummy.uncovered.addcode/dummy/')
     differ = CoberturaDiff(cobertura1, cobertura2)
 
-    assert differ.diff_missed_lines('dummy.py') == [(2, False), (3, True)]
+    assert differ.diff_missed_lines('dummy.py') == [(3, True)]
 
 
 def test_diff_total_hits():

--- a/tests/test_reporters.py
+++ b/tests/test_reporters.py
@@ -67,8 +67,8 @@ def test_text_report_delta__colorize_True():
 Filename         Stmts      Miss  Cover    Missing
 ---------------  -------  ------  -------  ---------
 dummy/dummy.py   -            \x1b[32m-2\x1b[39m  +40.00%
-dummy/dummy2.py  +2           \x1b[31m+1\x1b[39m  -25.00%  \x1b[31m+5\x1b[39m
-dummy/dummy3.py  +2           \x1b[31m+2\x1b[39m  -        \x1b[31m+1\x1b[39m, \x1b[31m+2\x1b[39m
+dummy/dummy2.py  +2           \x1b[31m+1\x1b[39m  -25.00%  \x1b[31m5\x1b[39m
+dummy/dummy3.py  +2           \x1b[31m+2\x1b[39m  -        \x1b[31m1\x1b[39m, \x1b[31m2\x1b[39m
 TOTAL            +4           \x1b[31m+1\x1b[39m  +31.06%"""
 
 
@@ -84,8 +84,8 @@ def test_text_report_delta__colorize_True__with_missing_range():
 Filename         Stmts      Miss  Cover    Missing
 ---------------  -------  ------  -------  ---------
 dummy/dummy.py   -            \x1b[32m-2\x1b[39m  +40.00%
-dummy/dummy2.py  +2           \x1b[31m+1\x1b[39m  -25.00%  \x1b[31m+5\x1b[39m
-dummy/dummy3.py  +2           \x1b[31m+2\x1b[39m  -        \x1b[31m+1\x1b[39m, \x1b[31m+2\x1b[39m
+dummy/dummy2.py  +2           \x1b[31m+1\x1b[39m  -25.00%  \x1b[31m5\x1b[39m
+dummy/dummy3.py  +2           \x1b[31m+2\x1b[39m  -        \x1b[31m1\x1b[39m, \x1b[31m2\x1b[39m
 TOTAL            +4           \x1b[31m+1\x1b[39m  +31.06%"""
 
 
@@ -101,8 +101,8 @@ def test_text_report_delta__colorize_False():
 Filename         Stmts      Miss  Cover    Missing
 ---------------  -------  ------  -------  ---------
 dummy/dummy.py   -            -2  +40.00%
-dummy/dummy2.py  +2           +1  -25.00%  +5
-dummy/dummy3.py  +2           +2  -        +1, +2
+dummy/dummy2.py  +2           +1  -25.00%  5
+dummy/dummy3.py  +2           +2  -        1, 2
 TOTAL            +4           +1  +31.06%"""
 
 
@@ -436,7 +436,7 @@ def test_html_report_delta():
             <td>+2</td>
             <td><span class="red">+1</span></td>
             <td>-25.00%</td>
-            <td><span class="red">+5</span>
+            <td><span class="red">5</span>
             </td>
           </tr>
           <tr>
@@ -444,7 +444,7 @@ def test_html_report_delta():
             <td>+2</td>
             <td><span class="red">+2</span></td>
             <td>-</td>
-            <td><span class="red">+1</span>, <span class="red">+2</span>
+            <td><span class="red">1</span>, <span class="red">2</span>
             </td>
           </tr>
         </tbody>

--- a/tests/test_reporters.py
+++ b/tests/test_reporters.py
@@ -65,9 +65,9 @@ def test_text_report_delta__colorize_True():
 
     assert report_delta.generate() == """\
 Filename         Stmts      Miss  Cover    Missing
----------------  -------  ------  -------  ----------
-dummy/dummy.py   -            \x1b[32m-2\x1b[39m  +40.00%  \x1b[32m-5\x1b[39m, \x1b[32m-6\x1b[39m
-dummy/dummy2.py  +2           \x1b[31m+1\x1b[39m  -25.00%  \x1b[32m-2\x1b[39m, \x1b[32m-4\x1b[39m, \x1b[31m+5\x1b[39m
+---------------  -------  ------  -------  ---------
+dummy/dummy.py   -            \x1b[32m-2\x1b[39m  +40.00%
+dummy/dummy2.py  +2           \x1b[31m+1\x1b[39m  -25.00%  \x1b[31m+5\x1b[39m
 dummy/dummy3.py  +2           \x1b[31m+2\x1b[39m  -        \x1b[31m+1\x1b[39m, \x1b[31m+2\x1b[39m
 TOTAL            +4           \x1b[31m+1\x1b[39m  +31.06%"""
 
@@ -82,9 +82,9 @@ def test_text_report_delta__colorize_True__with_missing_range():
 
     assert report_delta.generate() == """\
 Filename         Stmts      Miss  Cover    Missing
----------------  -------  ------  -------  ----------
-dummy/dummy.py   -            \x1b[32m-2\x1b[39m  +40.00%  \x1b[32m-5\x1b[39m, \x1b[32m-6\x1b[39m
-dummy/dummy2.py  +2           \x1b[31m+1\x1b[39m  -25.00%  \x1b[32m-2\x1b[39m, \x1b[32m-4\x1b[39m, \x1b[31m+5\x1b[39m
+---------------  -------  ------  -------  ---------
+dummy/dummy.py   -            \x1b[32m-2\x1b[39m  +40.00%
+dummy/dummy2.py  +2           \x1b[31m+1\x1b[39m  -25.00%  \x1b[31m+5\x1b[39m
 dummy/dummy3.py  +2           \x1b[31m+2\x1b[39m  -        \x1b[31m+1\x1b[39m, \x1b[31m+2\x1b[39m
 TOTAL            +4           \x1b[31m+1\x1b[39m  +31.06%"""
 
@@ -99,9 +99,9 @@ def test_text_report_delta__colorize_False():
 
     assert report_delta.generate() == """\
 Filename         Stmts      Miss  Cover    Missing
----------------  -------  ------  -------  ----------
-dummy/dummy.py   -            -2  +40.00%  -5, -6
-dummy/dummy2.py  +2           +1  -25.00%  -2, -4, +5
+---------------  -------  ------  -------  ---------
+dummy/dummy.py   -            -2  +40.00%
+dummy/dummy2.py  +2           +1  -25.00%  +5
 dummy/dummy3.py  +2           +2  -        +1, +2
 TOTAL            +4           +1  +31.06%"""
 
@@ -428,7 +428,7 @@ def test_html_report_delta():
             <td>-</td>
             <td><span class="green">-2</span></td>
             <td>+40.00%</td>
-            <td><span class="green">-5</span>, <span class="green">-6</span>
+            <td>
             </td>
           </tr>
           <tr>
@@ -436,7 +436,7 @@ def test_html_report_delta():
             <td>+2</td>
             <td><span class="red">+1</span></td>
             <td>-25.00%</td>
-            <td><span class="green">-2</span>, <span class="green">-4</span>, <span class="red">+5</span>
+            <td><span class="red">+5</span>
             </td>
           </tr>
           <tr>


### PR DESCRIPTION
Addresses https://github.com/aconrad/pycobertura/issues/148.
@aconrad Please review!
Unfortunately the `file_source` function is a bit unreadable for me, so I chose to return a tuple where the second element is always True. But probably at some point, we would like to separate the `line-edit` part.