### PR TITLE
Use markdown to display pycobertura logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # pycobertura
 
-<img src="aysha-logo.svg" alt="pycobertura logo" width="100">
+![pycobertura logo](https://raw.githubusercontent.com/aconrad/pycobertura/master/aysha-logo.svg)
 
 A code coverage diff tool for Cobertura reports.
 


### PR DESCRIPTION
On [Pypi](https://pypi.org/project/pycobertura/), the pycobertura logo is broken, see screenshot of pypi:

<img width="451" alt="Screen Shot 2022-10-09 at 7 27 55 PM" src="https://user-images.githubusercontent.com/247661/194770907-bbaa10de-bad8-404e-b5a9-c45d700754f6.png">

The other images in the README are properly displayed because they use Markdown but the logo uses the `<img>` tag.

Using `<img>` allows resizing the image but with Markdown it's not possible, at least not with Github (I tried [this](https://stackoverflow.com/a/21242579/91710)). So let's leave it large for now. It makes the logo more prominent, but why not, it's a beautiful logo. 😄 We could change the size in the SVG file but I just didn't want to tamper the original file.