### PR TITLE
filesystem: Wrap archived files inside TextIOWrapper

### DIFF
--- a/.github/workflows/build-and-test-pycobertura.yml
+++ b/.github/workflows/build-and-test-pycobertura.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v2

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-* Make `ZipFileSystem` read files in text mode to fix diffing mixed file systems
+* Make `ZipFileSystem` read files in text mode to fix diffing mixed file systems. Thanks @ernestask
 
 ## 3.2.0 (2023-05-12)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * Make `ZipFileSystem` read files in text mode to fix diffing mixed file systems. Thanks @ernestask
+* Add Python 3.11 as a supported version. Thanks @ernestask
 
 ## 3.2.0 (2023-05-12)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Make `ZipFileSystem` read files in text mode to fix diffing mixed file systems
+
 ## 3.2.0 (2023-05-12)
 
 * `pycobertura diff` now supports output format: `github-annotation`. Thanks @goatwu1993

--- a/pycobertura/filesystem.py
+++ b/pycobertura/filesystem.py
@@ -66,9 +66,9 @@ class ZipFileSystem(FileSystem):
         filename = self.real_filename(filename)
 
         try:
-            f = self.zipfile.open(filename)
-            yield f
-            f.close()
+            with self.zipfile.open(filename) as f:
+                with io.TextIOWrapper(f, encoding="utf-8") as t:
+                    yield t
         except KeyError:
             raise self.FileNotFound(filename)
 

--- a/tests/test_cobertura_diff.py
+++ b/tests/test_cobertura_diff.py
@@ -160,3 +160,13 @@ def test_diff__has_not_better_coverage():
     cobertura2 = Cobertura('tests/dummy.zeroexit1/coverage.xml')
     differ = CoberturaDiff(cobertura1, cobertura2)
     assert differ.has_better_coverage() is False
+
+
+def test_diff__mixed_filesystems():
+    from pycobertura.cobertura import Cobertura, CoberturaDiff
+
+    cobertura1 = make_cobertura('tests/dummy.original.xml', source='tests/dummy/dummy.zip')
+    cobertura2 = make_cobertura('tests/dummy.original.xml', source='tests/dummy')
+
+    differ = CoberturaDiff(cobertura1, cobertura2)
+    assert differ.has_all_changes_covered() is True

--- a/tests/test_filesystem.py
+++ b/tests/test_filesystem.py
@@ -102,6 +102,21 @@ def test_filesystem_zip__with_source_prefix():
             assert hasattr(f, 'read')
 
 
+def test_filesystem_zip__read_str():
+    from pycobertura.filesystem import ZipFileSystem
+
+    fs = ZipFileSystem("tests/dummy/dummy.zip")
+
+    source_files_in_zip = [
+        'dummy/dummy.py',
+        'dummy/dummy2.py',
+    ]
+
+    for source_file in source_files_in_zip:
+        with fs.open(source_file) as f:
+            assert isinstance(f.read(), str)
+
+
 def test_filesystem_git():
     import pycobertura.filesystem as fsm
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 skipsdist = True
-envlist = py37, py38, py39, py310, pep8, black
+envlist = py37, py38, py39, py310, py311, pep8, black
 
 [gh-actions]
 python =

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,7 @@ python =
     3.8: py38
     3.9: py39
     3.10: py310, pep8, black
+    3.11: py311
 
 [flake8]
 max-line-length = 88


### PR DESCRIPTION
Currently, when mixing DirectoryFileSystem and ZipFileSystem, diffing reports wrong results for identical coverage reports due to differing types in file systems (byte-string lines compared with text lines).

This commit wraps the files opened from a zip archive inside TextIOWrapper to avoid the issue.

Closes https://github.com/aconrad/pycobertura/issues/107