### PR TITLE
Enable executing as scripts

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Enable executing as scripts
+
 ## 3.2.4 (2023-12-08)
 
 * Fix: `Cobertura.branch_rate()` returns `None` when `branch-rate` is absent

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-* Enable executing as scripts
+* Support executing pycobertura as a python module with: `python -m pycobertura`. Thanks @paveltsialnou
 
 ## 3.2.4 (2023-12-08)
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ pip install pycobertura
 
 ## CLI usage
 
-pycobertura provides a command line interface to report on coverage files.
+pycobertura provides a command line interface to report on coverage files and also allows you to execute pycobertura module as scripts (see [PEP 338](https://peps.python.org/pep-0338/))
 
 ### Help commands
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,9 @@ pip install pycobertura
 
 ## CLI usage
 
-pycobertura provides a command line interface to report on coverage files and also allows you to execute pycobertura module as scripts (see [PEP 338](https://peps.python.org/pep-0338/))
+pycobertura provides a command line interface `pycobertura` to report on coverage files.
+
+Alternatively, pycobertura can also be invoked as a module with `python -m pycobertura`, see [PEP 338](https://peps.python.org/pep-0338/).
 
 ### Help commands
 

--- a/pycobertura/__main__.py
+++ b/pycobertura/__main__.py
@@ -1,0 +1,8 @@
+import click
+
+from .cli import pycobertura
+
+cli = click.CommandCollection(sources=[pycobertura])
+
+if __name__ == "__main__":
+    cli()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,10 @@
+import mock
+import runpy
+
+
+def test_cli():
+    with mock.patch("click.CommandCollection") as mock_cli:
+        runpy.run_module("pycobertura", run_name="__main__")
+
+    mock_cli.assert_called_once()
+    mock_cli.return_value.assert_called_once_with()


### PR DESCRIPTION
Enable executing as scripts (see [PEP 338](https://peps.python.org/pep-0338/)):
```shell
$ python -m pycobertura show coverage.xml 
Filename                             Stmts    Miss  Cover    Missing
---------------------------------  -------  ------  -------  ---------
pycobertura/__init__.py                  3       1  66.67%   0
pycobertura/cli.py                      90       0  100.00%
pycobertura/cobertura.py               213       0  100.00%
pycobertura/filesystem.py               87       0  100.00%
pycobertura/reporters.py               222       0  100.00%
pycobertura/utils.py                   130       1  99.23%   40
pycobertura/templates/__init__.py        0       0  100.00%
pycobertura/templates/filters.py        15       0  100.00%
TOTAL                                  760       2  99.74%
```