### PR TITLE
Fix total values when ignore regex used

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,8 @@
 # Release Notes
 
 ## Unreleased
+* Fix total stmts, miss and cover values in the coverage report when an ignore
+  regex is passed. Thanks @danctorres
 
 ## 3.3.0 (2024-01-14)
 

--- a/pycobertura/reporters.py
+++ b/pycobertura/reporters.py
@@ -45,9 +45,15 @@ class Reporter:
             ],
         }
         lines["Filename"].append("TOTAL")
-        lines["Stmts"] += [self.cobertura.total_statements()]
-        lines["Miss"] += [self.cobertura.total_misses()]
-        lines["Cover"] += [self.format_line_rate(self.cobertura.line_rate())]
+        lines["Stmts"] += [
+            self.cobertura.total_statements(ignore_regex=self.ignore_regex)
+        ]
+        lines["Miss"] += [self.cobertura.total_misses(ignore_regex=self.ignore_regex)]
+        lines["Cover"] += [
+            self.format_line_rate(
+                self.cobertura.line_rate(ignore_regex=self.ignore_regex)
+            )
+        ]
         lines["Missing"].append("")
 
         return lines

--- a/tests/test_reporters.py
+++ b/tests/test_reporters.py
@@ -43,6 +43,20 @@ dummy/dummy2.py          2       2  0.00%    1-2
 TOTAL                    6       2  66.67%"""
 
 
+def test_text_report__with_ignore_regex():
+    from pycobertura.reporters import TextReporter
+
+    cobertura = make_cobertura()
+    report = TextReporter(cobertura, ".*Main.java|.*ISortedArraySearch.java")
+
+    assert report.generate() == """\
+Filename                    Stmts    Miss  Cover    Missing
+------------------------  -------  ------  -------  ---------
+search/BinarySearch.java       12       1  91.67%   24
+search/LinearSearch.java        7       2  71.43%   19-24
+TOTAL                          19       3  84.21%"""
+
+
 def test_text_report_delta__no_diff():
     from pycobertura.reporters import TextReporterDelta
 


### PR DESCRIPTION
**Expected Behavior**:
The report should display the total values (stmts, miss, and cover), calculated for all files excluding those specified by the ignore_regex.

**Actual Behavior**:
Previously, when using ignore_regex to exclude files, the report's total values were incorrect. The values remained the same whether the ignore_regex argument was passed or not.

**Steps to Reproduce**:
`~/pycobertura >  pycobertura show --ignore-regex ".*Main|.*ISorted" --format markdown tests/cobertura.xml`

**Report Before Fix**:
```
| Filename                 |   Stmts |   Miss | Cover   | Missing   |
|--------------------------|---------|--------|---------|-----------|
| search/BinarySearch.java |      12 |      1 | 91.67%  | 24        |
| search/LinearSearch.java |       7 |      2 | 71.43%  | 19-24     |
| TOTAL                    |      34 |      3 | 90.00%  |           |
```

**Changes**:
- Added ignore_regex as an input to the functions responsible for calculating total values.
- Introduced a test to ensure correct total value calculation when using ignore_regex.

**Result**:
After the fix, the total values are now calculated correctly, reflected by the following report, generated with the same command.

**Report After Fix**:
```
| Filename                 |   Stmts |   Miss | Cover   | Missing   |
|--------------------------|---------|--------|---------|-----------|
| search/BinarySearch.java |      12 |      1 | 91.67%  | 24        |
| search/LinearSearch.java |       7 |      2 | 71.43%  | 19-24     |
| TOTAL                    |      19 |      3 | 84.21%  |           |
```