### PR TITLE
chore: Drop support for py37 and py38

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,9 @@
 [tox]
 skipsdist = True
-envlist = py37, py38, py39, py310, py311, pep8, black
+envlist = py39, py310, py311, pep8, black
 
 [gh-actions]
 python =
-    3.7: py37
-    3.8: py38
     3.9: py39
     3.10: py310, pep8, black
     3.11: py311


### PR DESCRIPTION
Those versions aren't supported anymore by the PSF.
