### PR TITLE
feat: add --fail-threshold option

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 * Add `--sort-by-uncovered-lines` to sort output, so the file with the most missing lines is at the
   top. Thanks @guettli
 * Fix: JSON and YAML output when using `--ignore-regex` in `show` command. Thanks @OidaTiftla
+* Add `--fail-threshold` to return a non-zero exit code when the total number of uncovered lines exceeds the specified threshold
 
 ## 4.1.0 (2025-04-13)
 

--- a/README.md
+++ b/README.md
@@ -219,6 +219,12 @@ $ pycobertura show --format github-annotation tests/cobertura.xml
 ::notice file=dummy/dummy4.py,line=1,endLine=6,title=pycobertura::not covered
 ```
 
+The following shows how to return a non-zero exit code when the line rate falls below the specified threshold.
+
+```shell
+$ pycobertura show --fail-under=80 cobertura.xml
+```
+
 If you run it in GitHub Actions/Apps, the above log generates check annotations.
 
 ![Example output of github-annotation formatted pycobertura show command](images/example_github_annotation_show.png)

--- a/README.md
+++ b/README.md
@@ -219,10 +219,10 @@ $ pycobertura show --format github-annotation tests/cobertura.xml
 ::notice file=dummy/dummy4.py,line=1,endLine=6,title=pycobertura::not covered
 ```
 
-The following shows how to return a non-zero exit code when the line rate falls below the specified threshold.
+The following shows how to return a non-zero exit code when the total number of uncovered lines falls above the specified threshold.
 
 ```shell
-$ pycobertura show --fail-under=80 cobertura.xml
+$ pycobertura show --fail-threshold=123 cobertura.xml
 ```
 
 If you run it in GitHub Actions/Apps, the above log generates check annotations.

--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ $ pycobertura show --format github-annotation tests/cobertura.xml
 ::notice file=dummy/dummy4.py,line=1,endLine=6,title=pycobertura::not covered
 ```
 
-The following shows how to return a non-zero exit code when the total number of uncovered lines falls above the specified threshold.
+The following shows how to return a non-zero exit code when the total number of uncovered lines exceeds the specified threshold.
 
 ```shell
 $ pycobertura show --fail-threshold=123 cobertura.xml

--- a/pycobertura/cli.py
+++ b/pycobertura/cli.py
@@ -39,7 +39,7 @@ class ExitCodes:
     EXCEPTION = 1
     COVERAGE_WORSENED = 2
     NOT_ALL_CHANGES_COVERED = 3
-    LINE_RATE_BELOW_THRESHOLD = 4
+    TOTAL_MISSES_ABOVE_THRESHOLD = 4
 
 
 def get_exit_code(differ: CoberturaDiff, source):
@@ -123,10 +123,11 @@ def get_exit_code(differ: CoberturaDiff, source):
     help="Sort the summary so files with the most uncovered lines appear first.",
 )
 @click.option(
-    "--fail-under",
+    "--fail-threshold",
     metavar="<threshold>",
-    type=click.FloatRange(0, 100, min_open=True),
-    help="Return a non-zero code if the line rate falls below the threshold.",
+    type=click.IntRange(min=1),
+    help="Return a non-zero code if the total number of uncovered statements "
+    "falls above the threshold.",
 )
 def show(
     cobertura_file,
@@ -140,7 +141,7 @@ def show(
     annotation_level,
     annotation_title,
     annotation_message,
-    fail_under,
+    fail_threshold,
 ):
     """show coverage summary of a Cobertura report"""
 
@@ -173,10 +174,9 @@ def show(
     isatty = True if output is None else output.isatty()
     click.echo(report, file=output, nl=isatty)
 
-    if fail_under is not None:
-        line_rate = 100 * cobertura.line_rate()
-        if line_rate < fail_under:
-            raise SystemExit(ExitCodes.LINE_RATE_BELOW_THRESHOLD)
+    if fail_threshold is not None:
+        if cobertura.total_misses() > fail_threshold:
+            raise SystemExit(ExitCodes.TOTAL_MISSES_ABOVE_THRESHOLD)
 
 
 delta_reporters = {

--- a/pycobertura/cli.py
+++ b/pycobertura/cli.py
@@ -154,7 +154,7 @@ def show(
     )
     Reporter = reporters[format]
     reporter_kwargs = {}
-    reporter_kwargs["sort_by_uncovered_lines"] = sort_by_uncovered_lines 
+    reporter_kwargs["sort_by_uncovered_lines"] = sort_by_uncovered_lines
     reporter = Reporter(cobertura, ignore_regex, **reporter_kwargs)
 
     if format == "csv":

--- a/pycobertura/cli.py
+++ b/pycobertura/cli.py
@@ -127,7 +127,7 @@ def get_exit_code(differ: CoberturaDiff, source):
     metavar="<threshold>",
     type=click.IntRange(min=1),
     help="Return a non-zero code if the total number of uncovered statements "
-    "falls above the threshold.",
+    "exceeds the threshold.",
 )
 def show(
     cobertura_file,

--- a/pycobertura/cli.py
+++ b/pycobertura/cli.py
@@ -190,8 +190,7 @@ delta_reporters = {
 }
 
 
-@pycobertura.command(
-    help="""\
+@pycobertura.command(help="""\
 The diff command compares and shows the changes between two Cobertura reports.
 
 NOTE: Reporting missing lines or showing the source code with the diff command
@@ -202,8 +201,7 @@ location. If the source is not accessible from the report's location, the
 options `--source1` and `--source2` are necessary to point to the source code
 directories (or zip archives). If the source is not available at all, pass
 `--no-source` but missing lines and source code will not be reported.
-"""
-)
+""")
 @click.argument("cobertura_file1")
 @click.argument("cobertura_file2")
 @click.option(

--- a/pycobertura/reporters.py
+++ b/pycobertura/reporters.py
@@ -13,7 +13,6 @@ from ruamel import yaml
 import json
 import io
 
-
 env = Environment(loader=PackageLoader("pycobertura", "templates"))
 env.filters["line_status"] = filters.line_status
 env.filters["line_reason"] = filters.line_reason_icon

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -35,7 +35,7 @@ def test_show__fail_threshold__invalid_value(fail_threshold):
     runner = CliRunner()
     result = runner.invoke(
         show,
-        ['tests/dummp.original.xml', f'--fail-threshold={fail_threshold}'],
+        ['tests/dummy.original.xml', f'--fail-threshold={fail_threshold}'],
         catch_exceptions=False,
     )
     assert result.output == f"""\
@@ -53,7 +53,7 @@ def test_show__fail_threshold__invalid_type(fail_threshold):
     runner = CliRunner()
     result = runner.invoke(
         show,
-        ['tests/dummp.original.xml', f'--fail-threshold={fail_threshold}'],
+        ['tests/dummy.original.xml', f'--fail-threshold={fail_threshold}'],
         catch_exceptions=False,
     )
     assert result.output == f"""\

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13,36 +13,54 @@ def test_exit_codes():
     assert ExitCodes.EXCEPTION == 1
     assert ExitCodes.COVERAGE_WORSENED == 2
     assert ExitCodes.NOT_ALL_CHANGES_COVERED == 3
-    assert ExitCodes.LINE_RATE_BELOW_THRESHOLD == 4
+    assert ExitCodes.TOTAL_MISSES_ABOVE_THRESHOLD == 4
 
 
-@pytest.mark.parametrize("fail_under, exit_code", ((0.1, ExitCodes.OK), (100, ExitCodes.LINE_RATE_BELOW_THRESHOLD)))
-def test_show__fail_under__exit_status(fail_under, exit_code):
+@pytest.mark.parametrize("fail_threshold, exit_code", ((1000, ExitCodes.OK), (1, ExitCodes.TOTAL_MISSES_ABOVE_THRESHOLD)))
+def test_show__fail_threshold__exit_status(fail_threshold, exit_code):
     from pycobertura.cli import show
 
     runner = CliRunner()
     result = runner.invoke(show, [
-        'tests/dummy.with-dummy2-better-and-worse.xml',  # has covered AND uncovered lines
-        f'--fail-under={fail_under}',
+        'tests/dummy.original.xml',
+        f'--fail-threshold={fail_threshold}',
     ], catch_exceptions=False)
     assert result.exit_code == exit_code
 
 
-@pytest.mark.parametrize('fail_under', (-1, 0, 0.0, 100.1, 101))
-def test_show__fail_under__invalid_value(fail_under):
+@pytest.mark.parametrize('fail_threshold', (-1, 0))
+def test_show__fail_threshold__invalid_value(fail_threshold):
     from pycobertura.cli import show
 
     runner = CliRunner()
     result = runner.invoke(
         show,
-        ['tests/dummp.original.xml', f'--fail-under={fail_under}'],
+        ['tests/dummp.original.xml', f'--fail-threshold={fail_threshold}'],
         catch_exceptions=False,
     )
     assert result.output == f"""\
 Usage: show [OPTIONS] COBERTURA_FILE
 Try 'show --help' for help.
 
-Error: Invalid value for '--fail-under': {fail_under:.1f} is not in the range 0<x<=100.
+Error: Invalid value for '--fail-threshold': {fail_threshold} is not in the range x>=1.
+"""
+
+
+@pytest.mark.parametrize('fail_threshold', (42.0, True, False, None))
+def test_show__fail_threshold__invalid_type(fail_threshold):
+    from pycobertura.cli import show
+
+    runner = CliRunner()
+    result = runner.invoke(
+        show,
+        ['tests/dummp.original.xml', f'--fail-threshold={fail_threshold}'],
+        catch_exceptions=False,
+    )
+    assert result.output == f"""\
+Usage: show [OPTIONS] COBERTURA_FILE
+Try 'show --help' for help.
+
+Error: Invalid value for '--fail-threshold': '{fail_threshold}' is not a valid integer range.
 """
 
 


### PR DESCRIPTION
Add new `--fail-under` option that allows to return non-zero exit code when `pycobertura show cobertura.xml` is used.