### PR TITLE
Fix JSON/YAML output when using `--ignore-regex` in `pycobertura show`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 
 * Add `--sort-by-uncovered-lines` to sort output, so the file with the most missing lines is at the
   top. Thanks @guettli
+* Fix: JSON and YAML output when using `--ignore-regex` in `show` command. Thanks @OidaTiftla
 
 ## 4.1.0 (2025-04-13)
 

--- a/pycobertura/reporters.py
+++ b/pycobertura/reporters.py
@@ -132,7 +132,9 @@ class Reporter:
         }
         """
         file_stats_dict_items = summary_lines.items()
-        number_of_files = len(self.cobertura.files()) + 1
+        # Use length from summary_lines instead of self.cobertura.files()
+        # to account for files filtered by ignore_regex
+        number_of_files = len(summary_lines["Filename"])
         file_stats_list = [
             {
                 header_name: header_value[file_index]


### PR DESCRIPTION
When converting a cobertura XML report to text, CSV, Markdown, or HTML, everything works correctly. However, converting to JSON failed when the `--ignore-regex` option was used.

The failure was caused by `per_file_stats` using the total number of files from `self.cobertura.files()`, which includes ignored files. This caused an `IndexError` because the filtered `summary_lines` list was shorter than expected.

**Exception example:**

```
Traceback (most recent call last):
  File ".../pycobertura-4.1.0/bin/.pycobertura-wrapped", line 9, in <module>
    sys.exit(pycobertura())
  File ".../site-packages/click/core.py", line 1485, in __call__
    return self.main(*args, **kwargs)
  File ".../site-packages/click/core.py", line 1406, in main
    rv = self.invoke(ctx)
  File ".../site-packages/click/core.py", line 1873, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File ".../site-packages/click/core.py", line 1269, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File ".../site-packages/click/core.py", line 824, in invoke
    return callback(*args, **kwargs)
  File ".../site-packages/pycobertura/cli.py", line 152, in show
    report = reporter.generate()
  File ".../site-packages/pycobertura/reporters.py", line 157, in generate
    stats_dict = self.per_file_stats(summary_lines)
  File ".../site-packages/pycobertura/reporters.py", line 104, in per_file_stats
    file_stats_list = [
  File ".../site-packages/pycobertura/reporters.py", line 105, in <listcomp>
    {
  File ".../site-packages/pycobertura/reporters.py", line 106, in <dictcomp>
    header_name: header_value[file_index]
IndexError: list index out of range
```

**Fix:**
Use the length of the filtered `summary_lines` instead of `self.cobertura.files()` when generating JSON output. This ensures that ignored files are correctly excluded without causing indexing errors.

**Tests added:**

* `test_show__format_json__with_ignore_regex`: verifies JSON output excludes ignored files and includes remaining files correctly.
* `test_show__format_yaml__with_ignore_regex`: verifies YAML output also respects `--ignore-regex`.

#### Result

JSON and YAML outputs now work and respect `--ignore-regex`, both in file listings and coverage totals.
